### PR TITLE
Restore requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: community.kubernetes
+    version: "<1.0.0"
+  - operator_sdk.util


### PR DESCRIPTION
During cleanup, I was a bit too eager and removed `requirements.yml` which is required by the operator.