### PR TITLE
Bump base image to 1.2.0 and clean

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,24 +1,7 @@
-FROM quay.io/operator-framework/ansible-operator:v0.18.2
+FROM quay.io/operator-framework/ansible-operator:v1.2.0
 
-USER root
+COPY requirements.yml requirements.yml
+RUN ansible-galaxy collection install -r requirements.yml
 
-RUN yum -y update && yum clean all
-
-RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
-
-RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
- && yum -y install python3-boto3 nss_wrapper \
- && yum clean all
-
-RUN ln -s ${HOME}/.ansible /.ansible
-COPY build/entrypoint /usr/local/bin/entrypoint
-
-USER 1001
-
-COPY requirements.yml ${HOME}/requirements.yml
-RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
- && chmod -R ug+rwx ${HOME}/.ansible
-
-COPY watches.yaml ${HOME}/watches.yaml
-
-COPY roles/ ${HOME}/roles/
+COPY watches.yaml watches.yaml
+COPY roles/ roles/

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,6 @@
 ---
 collections:
   - name: community.kubernetes
-    version: "<1.0.0"
-  - operator_sdk.util
+    version: 0.11.1
+  - name: operator_sdk.util
+    version: 0.0.0


### PR DESCRIPTION
The operator-framework/ansible-operator:v1.2.0 base image already prepares the environment.

However, to remain as close as possible to the registry.redhat.io/openshift-4/ose-ansible-operator:v4.6 image, we need to override the collections versions: `community.kubernetes:0.11.1` and `operator_sdk.util:0.0.0`.

The other RPMs are not needed in the context of Forklift, as we don't interact with AWS.