### PR TITLE
Rebase base image to v0.19.4

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,6 @@
-FROM quay.io/operator-framework/ansible-operator:v1.2.0
+FROM quay.io/operator-framework/ansible-operator:v0.19.4
 
+WORKDIR /opt/ansible
 COPY requirements.yml requirements.yml
 RUN ansible-galaxy collection install -r requirements.yml
 

--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -17,7 +17,7 @@
         phase: Reconciling
 
   - name: "Get the Infrastructure resource named cluster"
-    k8s_facts:
+    k8s_info:
       api_version: config.openshift.io/v1
       kind: Infrastructure
       name: cluster
@@ -69,7 +69,7 @@
       definition: "{{ lookup('template', 'route-inventory.yml.j2') }}"
 
   - name: "Check if UI oauthclient exists already so we don't update it"
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: OAuthClient
       name: "{{ ui_service_name }}"
@@ -114,7 +114,7 @@
 
   - block:
     - name: "Retrieve apiserver config definition"
-      k8s_facts:
+      k8s_info:
         api_version: "config.openshift.io/v1"
         kind: "apiserver"
         name: "cluster"
@@ -173,7 +173,7 @@
     when: not reconciled
 
   - name: Retrieve forklift controller status
-    k8s_facts:
+    k8s_info:
       api_version: forklift.konveyor.io/v1alpha1
       kind: ForkliftController
       namespace: "{{ app_namespace }}"


### PR DESCRIPTION
To match the OpenShift 4.6 setup, this pull request rebases the container on operator-sdk v0.19.4.
Since Ansible 2.9 and the introduction of collections, the `k8s_facts` module is replaced by `k8s_info`. This pull request also replaces all the calls to `k8s_facts` with `k8s_info`.