### PR TITLE
Add environment variable for metrics port in controller pod

### DIFF
--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -85,6 +85,8 @@ spec:
           value: /var/run/secrets/{{ inventory_service_name }}-serving-cert/tls.crt
         - name: API_TLS_KEY
           value: /var/run/secrets/{{ inventory_service_name }}-serving-cert/tls.key
+        - name: METRICS_PORT
+          value: '8081'
         envFrom:
         - configMapRef:
             name: {{ controller_configmap_name }}
@@ -93,7 +95,6 @@ spec:
         ports:
         - name: api
           containerPort: 8443
-          name: webhook-server
           protocol: TCP
         resources:
           limits:


### PR DESCRIPTION
With https://github.com/konveyor/forklift-controller/pull/131, we can set the port for the metrics service in the inventory container. To avoid port conflict, we set it to 8081, while the controller container will use the default 8080 port.