### PR TITLE
Get UI FQDN from route instead of infrastructure

### DIFF
--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -16,25 +16,30 @@
       status:
         phase: Reconciling
 
-  - name: "Get the Infrastructure resource named cluster"
-    k8s_info:
-      api_version: config.openshift.io/v1
-      kind: Infrastructure
-      name: cluster
-    register: infrastructures
+  - name: "Setup UI route"
+    k8s:
+      state: "present"
+      definition: "{{ lookup('template', 'route-ui.yml.j2') }}"
 
-  - name: "Get the cluster DNS suffic from the Infrastucture resource"
+  - name: "Obtain MTV UI route (timeout 60s)"
+    k8s_facts:
+      api_version: "route.openshift.io/v1"
+      kind: "Route"
+      namespace: "{{ app_namespace }}"
+      name: "{{ ui_route_name }}"
+    register: route
+    until: route.resources | length > 0
+    delay: 10
+    retries: 6
+
+  - name: "Get the Forklift UI FQDN from the route"
     set_fact:
-      cluster_dns_suffix: "{{ infrastructures.resources[0].status.etcdDiscoveryDomain }}"
-      when:
-      - infrastructures is defined
-      - infrastructures.resources | length > 0
-      - infrastructures.resources[0].get('status', {}).get('etcdDiscoveryDomain', '') != ''
+      ui_route_fqdn: "{{ route.resources[0].spec.host }}"
 
   - name: "Configure CORS allowed origins for UI"
     set_fact:
       cors_origins:
-      - "(?i)//{{ ui_route_name }}-{{ app_namespace }}.{{ cluster_dns_suffix }}(:|\\z)"
+      - "(?i)//{{ ui_route_fqdn }}(:|\\z)"
       - "//127.0.0.1(:|$)"
       - "//localhost(:|$)"
 
@@ -106,11 +111,6 @@
     k8s:
       state: "present"
       definition: "{{ lookup('template', 'deployment-ui.yml.j2') }}"
-
-  - name: "Setup UI route"
-    k8s:
-      state: "present"
-      definition: "{{ lookup('template', 'route-ui.yml.j2') }}"
 
   - block:
     - name: "Retrieve apiserver config definition"

--- a/roles/forkliftcontroller/templates/configmap-ui.yml.j2
+++ b/roles/forkliftcontroller/templates/configmap-ui.yml.j2
@@ -13,7 +13,7 @@ data:
       "inventoryApi": "https://{{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local:8443",
       "oauth": {
         "clientId": "{{ ui_service_name }}",
-        "redirectUrl": "https://{{ ui_route_name }}-{{ app_namespace }}.apps.{{ cluster_dns_suffix }}/login/callback",
+        "redirectUrl": "https://{{ ui_route_fqdn }}/login/callback",
         "userScope": "{{ ui_oauth_user_scope }}",
         "clientSecret": "{{ ui_oauth_secret }}"
       }

--- a/roles/forkliftcontroller/templates/oauthclient-ui.yml.j2
+++ b/roles/forkliftcontroller/templates/oauthclient-ui.yml.j2
@@ -6,5 +6,5 @@ metadata:
   namespace: "{{ app_namespace }}"
 grantMethod: auto
 redirectURIs:
-- "https://{{ ui_route_name }}-{{ app_namespace }}.apps.{{ cluster_dns_suffix }}/login/callback"
+- "https://{{ ui_route_fqdn }}/login/callback"
 secret: "{{ ui_oauth_secret }}"


### PR DESCRIPTION
With [BZ#1813012](https://bugzilla.redhat.com/show_bug.cgi?id=1813012), the `etcdDiscoveryDomain` attribute of the `cluster` infrastructure is not set by the OpenShift installer. The consequence is that the `cluster_dns_suffix` is empty and then the redirect URL for the OAuthClient CR is incomplete.

Moreover, Kubernetes doesn't have the `Infrastructure` kind, which is part of the `config.openshift.io/v1` API, so this configuration mechanism is not available in a Kubernetes cluster.

This pull request restores the previous mechanism. We create the UI route earlier, as it is the one we need for the redirect URL. Then, we retrieve the Route object and extract the FQDN from its spec.