### PR TITLE
Rename the default namespace to konveyor-forklift

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ Installing latest is almost an identical procedure to released versions but requ
 Custom settings can be applied by editing the `ForkliftController` CR.
 
 ```
-oc edit forkliftcontroller -n openshift-migration
+oc edit forkliftcontroller -n konveyor-forklift
 ```

--- a/deploy/olm-catalog/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: konveyor-forklift-operator.v99.0.0
-  namespace: openshift-migration
+  namespace: konveyor-forklift
   annotations:
     olm.skipRange: '>=0.0.0 <99.0.0'
     capabilities: Seamless Upgrades
@@ -19,7 +19,7 @@ metadata:
           "kind": "ForkliftController",
           "metadata": {
             "name": "forklift-controller",
-            "namespace": "openshift-migration"
+            "namespace": "konveyor-forklift"
           },
           "spec": {}
         },
@@ -28,12 +28,12 @@ metadata:
           "kind": "Migration",
           "metadata": {
             "name": "example-migration",
-            "namespace": "openshift-migration"
+            "namespace": "konveyor-forklift"
           },
           "spec": {
              "plan": {
                 "name": "example-plan",
-                "namespace": "openshift-migration"
+                "namespace": "konveyor-forklift"
              }
           }
         },
@@ -42,7 +42,7 @@ metadata:
           "kind": "Plan",
           "metadata": {
             "name": "example-plan",
-            "namespace": "openshift-migration"
+            "namespace": "konveyor-forklift"
           },
           "spec": {}
         },
@@ -51,7 +51,7 @@ metadata:
           "kind": "Provider",
           "metadata": {
             "name": "example-provider",
-            "namespace": "openshift-migration"
+            "namespace": "konveyor-forklift"
           },
           "spec": {
              "type": "vmware",
@@ -65,7 +65,7 @@ metadata:
       ]
     certified: "false"
     support: Red Hat
-    operatorframework.io/suggested-namespace: openshift-migration
+    operatorframework.io/suggested-namespace: konveyor-forklift
 spec:
   relatedImages:
   - name: controller

--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 app_name: "{{ lookup('env', 'APP_NAME') or 'forklift' }}"
-app_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') or 'openshift-migration' }}"
+app_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') or 'konveyor-forklift' }}"
 
 image_registry: "{{ lookup( 'env', 'IMAGE_REGISTRY') }}"
 image_org: "{{ lookup( 'env', 'IMAGE_ORG') }}"


### PR DESCRIPTION
Since this project should not be limited to OpenShift, this pull request renames the default namespace to `konveyor-forklift`.
It also better reflects the community the project belongs to.