### PR TITLE
Add BZ automation to repo

### DIFF
--- a/.github/workflows/bz-pr-action.yml
+++ b/.github/workflows/bz-pr-action.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: BZ PR Creation
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  pull_request_target:
+    branches:
+    - "*"
+    types:  
+    - opened
+    - edited
+    - reopened
+    - synchronize
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  bz-on-pr-create:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: docker://quay.io/konveyor/pr-bz-github-action 
+        name: update bugzilla with posted pr
+        with:
+          org_repo: ${{ github.repository }}
+          pr_number: ${{ github.event.pull_request.number }}
+          bz_product: "Migration Toolkit for Virtualization"
+          title: ${{ github.event.pull_request.title }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          bugzilla_token: ${{ secrets.BUGZILLA_TOKEN }} 

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: BZ Merge
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  pull_request_target:
+    branches:
+    - "*"
+    types:
+    - closed
+    
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in pnamearallel
+jobs:
+  # This workflow contains a single job called "build"
+  bz-on-pr-merge:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: docker://quay.io/konveyor/pr-merge-github-action
+        name: update bugzilla to modified
+        with:
+          bugzilla_token: ${{ secrets.BUGZILLA_TOKEN }}
+          org_repo: ${{ github.repository }}
+          pr_number: ${{ github.event.pull_request.number }}
+          bz_product: "Migration Toolkit for Virtualization"
+          title: ${{ github.event.pull_request.title }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch_to_release: "release-v2.0.0-beta.0:2.0.0-beta-1,main:2.0.0"
+          base_branch: ${{ github.base_ref }}

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -33,5 +33,5 @@ jobs:
           bz_product: "Migration Toolkit for Virtualization"
           title: ${{ github.event.pull_request.title }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch_to_release: "release-v2.0.0-beta.0:2.0.0-beta-1,main:2.0.0"
+          branch_to_release: "release-v2.0.0-beta.0:2.0.0-beta.1,main:2.0.0"
           base_branch: ${{ github.base_ref }}


### PR DESCRIPTION
- Add initial BZ automation via github actions, please review branch to release mappings
- Reference to the logic of GH -> BZ automation here for review as well : https://github.com/konveyor/bz-github-action/blob/master/README.md#notable-logic

**Other notes :**  
- There should be 1 PR to main/master branch and its corresponding PR to the release branch itself for the BZ automation to work properly, cherry picking will not suffice. @shawn-hurley for verification of this rule.
