### PR TITLE
Set policy agent url and search interval on inventory container

### DIFF
--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -22,6 +22,7 @@ validation_image_fqin: "{{ lookup( 'env', 'VALIDATION_IMAGE') }}"
 validation_service_name: "{{ app_name }}-validation"
 validation_deployment_name: "{{ validation_service_name }}"
 validation_container_name: "{{ app_name }}-validation"
+validation_policy_agent_search_interval: "10"
 
 inventory_volume_path: "/var/cache/inventory"
 inventory_container_name: "{{ app_name }}-inventory"

--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -22,7 +22,7 @@ validation_image_fqin: "{{ lookup( 'env', 'VALIDATION_IMAGE') }}"
 validation_service_name: "{{ app_name }}-validation"
 validation_deployment_name: "{{ validation_service_name }}"
 validation_container_name: "{{ app_name }}-validation"
-validation_policy_agent_search_interval: "10"
+validation_policy_agent_search_interval: "120"
 
 inventory_volume_path: "/var/cache/inventory"
 inventory_container_name: "{{ app_name }}-inventory"

--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -91,6 +91,12 @@ spec:
           value: /var/run/secrets/{{ inventory_service_name }}-serving-cert/tls.key
         - name: METRICS_PORT
           value: '8081'
+{% if feature_validation|bool %}
+        - name: POLICY_AGENT_URL
+          value: "https://{{ validation_service_name }}.{{ app_namespace }}.svc.cluster.local:8181"
+        - name: POLICY_AGENT_SEARCH_INTERVAL
+          value: "{{ validation_policy_agent_search_interval }}"
+{% endif %}
         envFrom:
         - configMapRef:
             name: {{ controller_configmap_name }}


### PR DESCRIPTION
* Fixes #88 
* Inject POLICY_AGENT_URL and POLICY_AGENT_SEARCH_INTERVAL to inventory container on controller pod
* validation_policy_agent_search_interval variable controls the search interval in seconds (default 10)
* Please note inventory container policy agent settings/variables are only populated when feature_validation is true (on by default)
