### PR TITLE
CSV: Update to require kube v1.20.0 as minimum

### DIFF
--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -388,7 +388,7 @@ spec:
   - name: Konveyor Forklift Operator
     url: https://github.com/konveyor/forklift-operator
   version: 99.0.0
-  minKubeVersion: 1.19.0
+  minKubeVersion: 1.20.0
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:


### PR DESCRIPTION
- Ensure a minimum kube release of v1.20.0 (OCP v4.7) is satisfied
- Needs also picking into release-v2.0.0 branch

Signed-off-by: Franco Bladilo <fbladilo@redhat.com>