### PR TITLE
CSV: Update to require kube v1.20.0 as minimum

### DIFF
--- a/bundle/manifests/konveyor-forklift-operator.v2.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v2.0.0.clusterserviceversion.yaml
@@ -388,7 +388,7 @@ spec:
   - name: Konveyor Forklift Operator
     url: https://github.com/konveyor/forklift-operator
   version: 2.0.0
-  minKubeVersion: 1.19.0
+  minKubeVersion: 1.20.0
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:


### PR DESCRIPTION
Picked for release-v2.0.0 , see #92 