### PR TITLE
UI: Expose OCP and forklift versions

### DIFF
--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -274,6 +274,7 @@ spec:
           - config.openshift.io
           resources:
           - infrastructures
+          - clusterversions
           verbs:
           - get
         - apiGroups:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
 # Konveyor Forklift Operator Documentation
 
 ## Upstream Release Instructions
-See [releases.md](./release.md) for details.
+See [releases.md](./releases.md) for details.

--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -7,6 +7,7 @@ feature_ui: true
 feature_validation: true
 
 image_pull_policy: Always
+forklift_operator_version: "latest"
 
 controller_image_fqin: "{{ lookup( 'env', 'CONTROLLER_IMAGE') }}"
 controller_configmap_name: "{{ controller_service_name }}-config"

--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -89,6 +89,18 @@
 
   - when: feature_ui
     block:
+    - name: "Obtain OCP version"
+      k8s_info:
+        kind: ClusterVersion
+        name: version
+      register: ocp_cv
+
+    - name: "Extract OCP version"
+      set_fact:
+        forklift_cluster_version: "{{ ocp_cv | json_query(query) | first }}"
+      vars:
+        query: "resources[0].status.history[?state=='Completed'].version"
+
     - name: "Check if UI oauthclient exists already so we don't update it"
       k8s_info:
         api_version: v1

--- a/roles/forkliftcontroller/templates/deployment-ui.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-ui.yml.j2
@@ -27,6 +27,10 @@ spec:
               value: {{ ui_configmap_path }}/{{ ui_meta_file_name }}
             - name: NODE_EXTRA_CA_CERTS
               value: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+            - name: FORKLIFT_OPERATOR_VERSION
+              value: {{ forklift_operator_version }}
+            - name: FORKLIFT_CLUSTER_VERSION
+              value: {{ forklift_cluster_version }}
           ports:
             - containerPort: 8443
               protocol: TCP

--- a/tools/cut-release.yml
+++ b/tools/cut-release.yml
@@ -62,6 +62,12 @@
       regexp: 'LABEL operators.operatorframework.io.bundle.channels.v1=.*'
       replace: "LABEL operators.operatorframework.io.bundle.channels.v1={{ channel }}"
 
+  - name: "Replace version in defaults/main.yml"
+    replace:
+      path: "{{ repo_root }}/roles/forkliftcontroller/defaults/main.yml"
+      regexp: 'forklift_operator_version:.*'
+      replace: "forklift_operator_version: \"{{ release }}\""
+
   - name: "Validate release-v{{ release }} bundle"
     shell: "operator-sdk bundle validate {{ repo_root }}/bundle"
     tags: validate


### PR DESCRIPTION
- Fetch and expose OCP ClusterVersion from config API on container using the FORKLIFT_CLUSTER_VERSION env variable, it targets the latest completed version running on the cluster 
- Set a role var indicating the operator version and also expose to UI via FORKLIFT_OPERATOR_VERSION
- RBAC updates
- Documentation and release scripts update
- Fixes #94 
- Tested on OCP v4.7

Sample env from UI container : 
```
    Environment:
      META_FILE:                  /etc/forklift-ui/meta.json
      NODE_EXTRA_CA_CERTS:        /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
      FORKLIFT_OPERATOR_VERSION:  latest
      FORKLIFT_CLUSTER_VERSION:   4.7.3
```