### PR TITLE
Remove legacy k8s_facts calls from ansible role

### DIFF
--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -24,7 +24,7 @@
         definition: "{{ lookup('template', 'route-ui.yml.j2') }}"
 
     - name: "Obtain MTV UI route (timeout 60s)"
-      k8s_facts:
+      k8s_info:
         api_version: "route.openshift.io/v1"
         kind: "Route"
         namespace: "{{ app_namespace }}"


### PR DESCRIPTION
Cleanup leftover k8s_facts calls from forkliftcontroller role