### PR TITLE
Fix regression in spec validation for forkliftcontrollers CRD

### DIFF
--- a/bundle/manifests/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/bundle/manifests/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -30,15 +30,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: ForkliftController specification.
-            properties:
-              feature_ui:
-                description: Deploy UI feature [true,false].
-                type: string
-              feature_validation:
-                description: Deploy validation feature [true,false].
-                type: string
+            description: Spec defines the desired state of ForkliftController
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: Status defines the observed state of ForkliftController
             type: object

--- a/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -30,15 +30,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: ForkliftController specification.
-            properties:
-              feature_ui:
-                description: Deploy UI feature [true,false].
-                type: string
-              feature_validation:
-                description: Deploy validation feature [true,false].
-                type: string
+            description: Spec defines the desired state of ForkliftController
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: Status defines the observed state of ForkliftController
             type: object


### PR DESCRIPTION
Current CRD spec validation ignores CR customizations as unknown fields are not being preserved, only declared properties , this reverts the behavior and allows again customizing all variables (images, etc) within the CR.