### PR TITLE
Sync CRDs

### DIFF
--- a/bundle/manifests/forklift.konveyor.io_migrations.yaml
+++ b/bundle/manifests/forklift.konveyor.io_migrations.yaml
@@ -305,6 +305,9 @@ spec:
                             - completed
                             - total
                             type: object
+                          reason:
+                            description: Reason
+                            type: string
                           started:
                             description: Started timestamp.
                             format: date-time
@@ -360,6 +363,9 @@ spec:
                                   - completed
                                   - total
                                   type: object
+                                reason:
+                                  description: Reason
+                                  type: string
                                 started:
                                   description: Started timestamp.
                                   format: date-time

--- a/bundle/manifests/forklift.konveyor.io_networkmaps.yaml
+++ b/bundle/manifests/forklift.konveyor.io_networkmaps.yaml
@@ -184,6 +184,21 @@ spec:
                 description: The most recent generation observed by the controller.
                 format: int64
                 type: integer
+              references:
+                items:
+                  description: Source reference. Either the ID or Name must be specified.
+                  properties:
+                    id:
+                      description: 'The object ID. vsphere:   The managed object ID.'
+                      type: string
+                    name:
+                      description: 'An object Name. vsphere:   A qualified name.'
+                      type: string
+                    type:
+                      description: Type used to qualify the name.
+                      type: string
+                  type: object
+                type: array
             type: object
         type: object
     served: true

--- a/bundle/manifests/forklift.konveyor.io_plans.yaml
+++ b/bundle/manifests/forklift.konveyor.io_plans.yaml
@@ -623,6 +623,9 @@ spec:
                                 - completed
                                 - total
                                 type: object
+                              reason:
+                                description: Reason
+                                type: string
                               started:
                                 description: Started timestamp.
                                 format: date-time
@@ -678,6 +681,9 @@ spec:
                                       - completed
                                       - total
                                       type: object
+                                    reason:
+                                      description: Reason
+                                      type: string
                                     started:
                                       description: Started timestamp.
                                       format: date-time

--- a/bundle/manifests/forklift.konveyor.io_storagemaps.yaml
+++ b/bundle/manifests/forklift.konveyor.io_storagemaps.yaml
@@ -188,6 +188,21 @@ spec:
                 description: The most recent generation observed by the controller.
                 format: int64
                 type: integer
+              references:
+                items:
+                  description: Source reference. Either the ID or Name must be specified.
+                  properties:
+                    id:
+                      description: 'The object ID. vsphere:   The managed object ID.'
+                      type: string
+                    name:
+                      description: 'An object Name. vsphere:   A qualified name.'
+                      type: string
+                    type:
+                      description: Type used to qualify the name.
+                      type: string
+                  type: object
+                type: array
             type: object
         type: object
     served: true


### PR DESCRIPTION
Syncs latest CRD updates from the controller. These will need to be backported to 2.0.0.