### PR TITLE
Update CRDs to v1beta1 API version

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -4,5 +4,5 @@ projectName: forklift-operator
 resources:
 - group: forklift
   kind: ForkliftController
-  version: v1alpha1
+  version: v1beta1
 version: 3-alpha

--- a/bundle/manifests/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/bundle/manifests/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -12,7 +12,7 @@ spec:
     singular: forkliftcontroller
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - name: v1beta1
     schema:
       openAPIV3Schema:
         description: ForkliftController is the Schema for the forkliftcontrollers API

--- a/bundle/manifests/forklift.konveyor.io_hooks.yaml
+++ b/bundle/manifests/forklift.konveyor.io_hooks.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/bundle/manifests/forklift.konveyor.io_hooks.yaml
+++ b/bundle/manifests/forklift.konveyor.io_hooks.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -25,7 +26,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1alpha1
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Hook is the Schema for the hooks API
@@ -61,6 +62,7 @@ spec:
             description: Hook status.
             properties:
               conditions:
+                description: List of conditions.
                 items:
                   description: Condition
                   properties:

--- a/bundle/manifests/forklift.konveyor.io_hosts.yaml
+++ b/bundle/manifests/forklift.konveyor.io_hosts.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/bundle/manifests/forklift.konveyor.io_hosts.yaml
+++ b/bundle/manifests/forklift.konveyor.io_hosts.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -25,7 +26,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
-    name: v1alpha1
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:
@@ -114,6 +115,7 @@ spec:
             description: HostStatus defines the observed state of Host
             properties:
               conditions:
+                description: List of conditions.
                 items:
                   description: Condition
                   properties:

--- a/bundle/manifests/forklift.konveyor.io_migrations.yaml
+++ b/bundle/manifests/forklift.konveyor.io_migrations.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/bundle/manifests/forklift.konveyor.io_migrations.yaml
+++ b/bundle/manifests/forklift.konveyor.io_migrations.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -31,7 +32,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
-    name: v1alpha1
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:
@@ -102,6 +103,7 @@ spec:
                 format: date-time
                 type: string
               conditions:
+                description: List of conditions.
                 items:
                   description: Condition
                   properties:
@@ -157,6 +159,7 @@ spec:
                       format: date-time
                       type: string
                     conditions:
+                      description: List of conditions.
                       items:
                         description: Condition
                         properties:

--- a/bundle/manifests/forklift.konveyor.io_networkmaps.yaml
+++ b/bundle/manifests/forklift.konveyor.io_networkmaps.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/bundle/manifests/forklift.konveyor.io_networkmaps.yaml
+++ b/bundle/manifests/forklift.konveyor.io_networkmaps.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22,7 +23,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
-    name: v1alpha1
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:
@@ -143,6 +144,7 @@ spec:
             description: MapStatus defines the observed state of Maps.
             properties:
               conditions:
+                description: List of conditions.
                 items:
                   description: Condition
                   properties:

--- a/bundle/manifests/forklift.konveyor.io_plans.yaml
+++ b/bundle/manifests/forklift.konveyor.io_plans.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/bundle/manifests/forklift.konveyor.io_plans.yaml
+++ b/bundle/manifests/forklift.konveyor.io_plans.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -31,7 +32,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
-    name: v1alpha1
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:
@@ -171,8 +172,30 @@ spec:
                 description: Target namespace.
                 type: string
               transferNetwork:
-                description: Name of the network attachment definition in the target namespace which should be used for disk transfer.
-                type: string
+                description: The network attachment definition that should be used for disk transfer.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
               vms:
                 description: List of VMs.
                 items:
@@ -239,6 +262,7 @@ spec:
             description: PlanStatus defines the observed state of Plan.
             properties:
               conditions:
+                description: List of conditions.
                 items:
                   description: Condition
                   properties:
@@ -289,6 +313,7 @@ spec:
                       description: Snapshot
                       properties:
                         conditions:
+                          description: List of conditions.
                           items:
                             description: Condition
                             properties:
@@ -475,6 +500,7 @@ spec:
                           format: date-time
                           type: string
                         conditions:
+                          description: List of conditions.
                           items:
                             description: Condition
                             properties:

--- a/bundle/manifests/forklift.konveyor.io_providers.yaml
+++ b/bundle/manifests/forklift.konveyor.io_providers.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/bundle/manifests/forklift.konveyor.io_providers.yaml
+++ b/bundle/manifests/forklift.konveyor.io_providers.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -34,7 +35,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
-    name: v1alpha1
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:
@@ -88,6 +89,7 @@ spec:
             description: ProviderStatus defines the observed state of Provider
             properties:
               conditions:
+                description: List of conditions.
                 items:
                   description: Condition
                   properties:

--- a/bundle/manifests/forklift.konveyor.io_provisioners.yaml
+++ b/bundle/manifests/forklift.konveyor.io_provisioners.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/bundle/manifests/forklift.konveyor.io_provisioners.yaml
+++ b/bundle/manifests/forklift.konveyor.io_provisioners.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -15,7 +16,7 @@ spec:
     singular: provisioner
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - name: v1beta1
     schema:
       openAPIV3Schema:
         properties:
@@ -91,6 +92,7 @@ spec:
             description: ProvisionerStatus defines the observed state of Provisioner
             properties:
               conditions:
+                description: List of conditions.
                 items:
                   description: Condition
                   properties:

--- a/bundle/manifests/forklift.konveyor.io_storagemaps.yaml
+++ b/bundle/manifests/forklift.konveyor.io_storagemaps.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/bundle/manifests/forklift.konveyor.io_storagemaps.yaml
+++ b/bundle/manifests/forklift.konveyor.io_storagemaps.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22,7 +23,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
-    name: v1alpha1
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:
@@ -147,6 +148,7 @@ spec:
             description: MapStatus defines the observed state of Maps.
             properties:
               conditions:
+                description: List of conditions.
                 items:
                   description: Condition
                   properties:

--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     alm-examples: |-
       [
         {
-          "apiVersion": "forklift.konveyor.io/v1alpha1",
+          "apiVersion": "forklift.konveyor.io/v1beta1",
           "kind": "ForkliftController",
           "metadata": {
             "name": "forklift-controller",
@@ -27,7 +27,7 @@ metadata:
           }
         },
         {
-          "apiVersion": "forklift.konveyor.io/v1alpha1",
+          "apiVersion": "forklift.konveyor.io/v1beta1",
           "kind": "Migration",
           "metadata": {
             "name": "example-migration",
@@ -41,7 +41,7 @@ metadata:
           }
         },
         {
-          "apiVersion": "forklift.konveyor.io/v1alpha1",
+          "apiVersion": "forklift.konveyor.io/v1beta1",
           "kind": "Plan",
           "metadata": {
             "name": "example-plan",
@@ -50,7 +50,7 @@ metadata:
           "spec": {}
         },
         {
-          "apiVersion": "forklift.konveyor.io/v1alpha1",
+          "apiVersion": "forklift.konveyor.io/v1beta1",
           "kind": "Provider",
           "metadata": {
             "name": "example-provider",
@@ -67,7 +67,7 @@ metadata:
         },
         {
           "kind": "Host",
-          "apiVersion": "forklift.konveyor.io/v1alpha1",
+          "apiVersion": "forklift.konveyor.io/v1beta1",
           "metadata": {
             "name": "example-host",
             "namespace": "konveyor-forklift"
@@ -83,7 +83,7 @@ metadata:
         },
         {
           "kind": "NetworkMap",
-          "apiVersion": "forklift.konveyor.io/v1alpha1",
+          "apiVersion": "forklift.konveyor.io/v1beta1",
           "metadata": {
              "name": "example-networkmap",
              "namespace": "konveyor-forklift"
@@ -109,7 +109,7 @@ metadata:
         },
         {
           "kind": "StorageMap",
-          "apiVersion": "forklift.konveyor.io/v1alpha1",
+          "apiVersion": "forklift.konveyor.io/v1beta1",
           "metadata": {
              "name": "example-storagemap",
              "namespace": "konveyor-forklift"
@@ -133,7 +133,7 @@ metadata:
         },
         {
            "kind": "Hook",
-           "apiVersion": "forklift.konveyor.io/v1alpha1",
+           "apiVersion": "forklift.konveyor.io/v1beta1",
            "metadata": {
               "name": "example-hook",
               "namespace": "konveyor-forklift"
@@ -143,7 +143,7 @@ metadata:
               "playbook": "<base64-encoded-playbook>"
            }
         },
-        {"kind":"Provisioner","apiVersion":"forklift.konveyor.io/v1alpha1","metadata":{"name":"cinder","namespace":"konveyor-forklift"},"spec":{"name":"kubernetes.io/cinder","volumeModes":[{"name":"Block","priority":0,"accessModes":[{"name":"ReadWriteOnce","priority":0},{"name":"ReadWriteMany","priority":1}]},{"name":"Filesystem","priority":1,"accessModes":[{"name":"ReadWriteOnce","priority":0},{"name":"ReadWriteMany","priority":1}]}]}}
+        {"kind":"Provisioner","apiVersion":"forklift.konveyor.io/v1beta1","metadata":{"name":"cinder","namespace":"konveyor-forklift"},"spec":{"name":"kubernetes.io/cinder","volumeModes":[{"name":"Block","priority":0,"accessModes":[{"name":"ReadWriteOnce","priority":0},{"name":"ReadWriteMany","priority":1}]},{"name":"Filesystem","priority":1,"accessModes":[{"name":"ReadWriteOnce","priority":0},{"name":"ReadWriteMany","priority":1}]}]}}
       ]
     certified: "false"
     support: Red Hat
@@ -394,47 +394,47 @@ spec:
   customresourcedefinitions:
     owned:
     - name: forkliftcontrollers.forklift.konveyor.io
-      version: v1alpha1
+      version: v1beta1
       kind: ForkliftController
       displayName: ForkliftController
       description: VM migration controller
     - name: migrations.forklift.konveyor.io
-      version: v1alpha1
+      version: v1beta1
       kind: Migration
       displayName: Migration
       description: VM migration
     - name: plans.forklift.konveyor.io
-      version: v1alpha1
+      version: v1beta1
       kind: Plan
       displayName: Plan
       description: VM migration plan
     - name: providers.forklift.konveyor.io
-      version: v1alpha1
+      version: v1beta1
       kind: Provider
       displayName: Provider
       description: VM provider
     - name: hosts.forklift.konveyor.io
-      version: v1alpha1
+      version: v1beta1
       kind: Host
       displayName: Host
       description: VM host
     - name: networkmaps.forklift.konveyor.io
-      version: v1alpha1
+      version: v1beta1
       kind: NetworkMap
       displayName: NetworkMap
       description: VM network map
     - name: storagemaps.forklift.konveyor.io
-      version: v1alpha1
+      version: v1beta1
       kind: StorageMap
       displayName: StorageMap
       description: VM storage map
     - name: provisioners.forklift.konveyor.io
-      version: v1alpha1
+      version: v1beta1
       kind: Provisioner
       displayName: Provisioner
       description: Storage Provisioner Capabilities
     - name: hooks.forklift.konveyor.io
-      version: v1alpha1
+      version: v1beta1
       kind: Hook
       displayName: Hook
       description: Hook schema for the hooks API

--- a/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
+++ b/config/crd/bases/forklift.konveyor.io_forkliftcontrollers.yaml
@@ -12,7 +12,7 @@ spec:
     singular: forkliftcontroller
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - name: v1beta1
     schema:
       openAPIV3Schema:
         description: ForkliftController is the Schema for the forkliftcontrollers API

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,7 +38,7 @@ rules:
       - update
       - watch
   ##
-  ## Rules for forklift.konveyor.io/v1alpha1, Kind: ForkliftController
+  ## Rules for forklift.konveyor.io/v1beta1, Kind: ForkliftController
   ##
   - apiGroups:
       - forklift.konveyor.io

--- a/config/samples/forklift_v1beta1_forkliftcontroller.yaml
+++ b/config/samples/forklift_v1beta1_forkliftcontroller.yaml
@@ -1,4 +1,4 @@
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: ForkliftController
 metadata:
   name: forklift-controller

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,4 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
-- forklift_v1alpha1_forkliftcontroller.yaml
+- forklift_v1beta1_forkliftcontroller.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/molecule/default/tasks/forkliftcontroller_test.yml
+++ b/molecule/default/tasks/forkliftcontroller_test.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create the forklift.konveyor.io/v1alpha1.ForkliftController
+- name: Create the forklift.konveyor.io/v1beta1.ForkliftController
   k8s:
     state: present
     namespace: '{{ namespace }}'
@@ -11,7 +11,7 @@
       reason: Successful
       status: "True"
   vars:
-    cr_file: 'forklift_v1alpha1_forkliftcontroller.yaml'
+    cr_file: 'forklift_v1beta1_forkliftcontroller.yaml'
 
 - name: Add assertions here
   assert:

--- a/roles/forkliftcontroller/templates/provider-host.yml.j2
+++ b/roles/forkliftcontroller/templates/provider-host.yml.j2
@@ -1,6 +1,6 @@
 ---
 kind: Provider
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 metadata:
   name: host
   namespace: {{ app_namespace }}

--- a/roles/forkliftcontroller/templates/provisioner-aws-ebs.yml.j2
+++ b/roles/forkliftcontroller/templates/provisioner-aws-ebs.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provisioner
 metadata:
   name: aws-ebs

--- a/roles/forkliftcontroller/templates/provisioner-azure-disk.yml.j2
+++ b/roles/forkliftcontroller/templates/provisioner-azure-disk.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provisioner
 metadata:
   name: azure-disk

--- a/roles/forkliftcontroller/templates/provisioner-azure-file.yml.j2
+++ b/roles/forkliftcontroller/templates/provisioner-azure-file.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provisioner
 metadata:
   name: azure-file

--- a/roles/forkliftcontroller/templates/provisioner-cinder.yml.j2
+++ b/roles/forkliftcontroller/templates/provisioner-cinder.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provisioner
 metadata:
   name: cinder

--- a/roles/forkliftcontroller/templates/provisioner-gce-pd.yml.j2
+++ b/roles/forkliftcontroller/templates/provisioner-gce-pd.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provisioner
 metadata:
   name: gce-pd

--- a/roles/forkliftcontroller/templates/provisioner-hostpath-provisioner.yml.j2
+++ b/roles/forkliftcontroller/templates/provisioner-hostpath-provisioner.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provisioner
 metadata:
   name: hostpath-provisioner

--- a/roles/forkliftcontroller/templates/provisioner-manila.yml.j2
+++ b/roles/forkliftcontroller/templates/provisioner-manila.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provisioner
 metadata:
   name: manila

--- a/roles/forkliftcontroller/templates/provisioner-openshiftstorage.cephfs.csi.ceph.com.yml.j2
+++ b/roles/forkliftcontroller/templates/provisioner-openshiftstorage.cephfs.csi.ceph.com.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provisioner
 metadata:
   name: ocs-cephfs

--- a/roles/forkliftcontroller/templates/provisioner-openshiftstorage.rbd.csi.ceph.com.yml.j2
+++ b/roles/forkliftcontroller/templates/provisioner-openshiftstorage.rbd.csi.ceph.com.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provisioner
 metadata:
   name: ocs-rbd

--- a/roles/forkliftcontroller/templates/provisioner-rbd.yml.j2
+++ b/roles/forkliftcontroller/templates/provisioner-rbd.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provisioner
 metadata:
   name: rbd

--- a/roles/forkliftcontroller/templates/provisioner-vsphere-volume.yml.j2
+++ b/roles/forkliftcontroller/templates/provisioner-vsphere-volume.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: forklift.konveyor.io/v1alpha1
+apiVersion: forklift.konveyor.io/v1beta1
 kind: Provisioner
 metadata:
   name: vsphere-volume

--- a/watches.yaml
+++ b/watches.yaml
@@ -1,5 +1,5 @@
 ---
-- version: v1alpha1
+- version: v1beta1
   group: forklift.konveyor.io
   kind: ForkliftController
   role: /opt/ansible/roles/forkliftcontroller


### PR DESCRIPTION
Forklift API is promoted to `v1beta1`. This pull request updates the CRDs and all other references.