### PR TITLE
Add logging and profiler settings to controller

### DIFF
--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -199,7 +199,7 @@ spec:
                   value: quay.io/konveyor/forklift-ui:latest
                 - name: VALIDATION_IMAGE
                   value: quay.io/konveyor/forklift-validation:latest
-                image: quay.io/konveyor/forklift-operator:latest
+                image: quay.io/fbladilo/forklift-operator:latest
                 imagePullPolicy: Always
                 name: forklift-operator
                 resources: {}

--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -199,7 +199,7 @@ spec:
                   value: quay.io/konveyor/forklift-ui:latest
                 - name: VALIDATION_IMAGE
                   value: quay.io/konveyor/forklift-validation:latest
-                image: quay.io/fbladilo/forklift-operator:latest
+                image: quay.io/konveyor/forklift-operator:latest
                 imagePullPolicy: Always
                 name: forklift-operator
                 resources: {}

--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -18,6 +18,7 @@ controller_container_limits_cpu: "100m"
 controller_container_limits_memory: "800Mi"
 controller_container_requests_cpu: "100m"
 controller_container_requests_memory: "350Mi"
+profiler_volume_path: "/var/cache/profiler"
 
 validation_image_fqin: "{{ lookup( 'env', 'VALIDATION_IMAGE') }}"
 validation_service_name: "{{ app_name }}-validation"

--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -49,6 +49,18 @@ spec:
           value: "true"
         - name: SECRET_NAME
           value: webhook-server-secret
+{% if controller_log_level is defined and controller_log_level is integer %}
+        - name: LOG_LEVEL
+          value: "{{ controller_log_level }}"
+{% endif %}
+{% if controller_profile_kind is defined and controller_profile_path is defined and controller_profile_duration is defined %}
+        - name: PROFILE_KIND
+          value: "{{ controller_profile_kind }}"
+        - name: PROFILE_PATH
+          value: "{{ controller_profile_path }}"
+        - name: PROFILE_DURATION
+          value: "{{ controller_profile_duration }}"
+{% endif %}
         envFrom:
         - configMapRef:
             name: {{ controller_configmap_name }}
@@ -69,6 +81,8 @@ spec:
         - mountPath: /tmp/cert
           name: cert
           readOnly: true
+        - mountPath: {{ profiler_volume_path }}
+          name: profiler
       - name: inventory
         command:
         - /usr/local/bin/manager
@@ -97,9 +111,17 @@ spec:
         - name: POLICY_AGENT_SEARCH_INTERVAL
           value: "{{ validation_policy_agent_search_interval }}"
 {% endif %}
-{% if controller_log_level is defined %}
+{% if controller_log_level is defined and controller_log_level is integer %}
         - name: LOG_LEVEL
-          value: controller_log_level
+          value: "{{ controller_log_level }}"
+{% endif %}
+{% if controller_profile_kind is defined and controller_profile_path is defined and controller_profile_duration is defined %}
+        - name: PROFILE_KIND
+          value: "{{ controller_profile_kind }}"
+        - name: PROFILE_PATH
+          value: "{{ controller_profile_path }}"
+        - name: PROFILE_DURATION
+          value: "{{ controller_profile_duration }}"
 {% endif %}
         envFrom:
         - configMapRef:
@@ -120,6 +142,8 @@ spec:
         volumeMounts:
         - mountPath: {{ inventory_volume_path }}
           name: inventory
+        - mountPath: {{ profiler_volume_path }}
+          name: profiler
         - mountPath: /var/run/secrets/{{ inventory_service_name }}-serving-cert
           name: {{ inventory_service_name }}-serving-cert
       terminationGracePeriodSeconds: 10
@@ -133,4 +157,6 @@ spec:
           defaultMode: 420
           secretName: {{ inventory_service_name }}-serving-cert
       - name: inventory
+        emptyDir: {}
+      - name: profiler
         emptyDir: {}

--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -97,6 +97,10 @@ spec:
         - name: POLICY_AGENT_SEARCH_INTERVAL
           value: "{{ validation_policy_agent_search_interval }}"
 {% endif %}
+{% if controller_log_level is defined %}
+        - name: LOG_LEVEL
+          value: controller_log_level
+{% endif %}
         envFrom:
         - configMapRef:
             name: {{ controller_configmap_name }}


### PR DESCRIPTION
This PR adds settings support for profiling and logging into the controller pod, settings can be injected into the forkliftcontroller CR spec, by default they are unset/disabled. The following environmental variables would be exposed to both containers in the controller pod when set: 

```
    LOG_LEVEL: Set the verbosity.
    PROFILE_KIND: Kind of profile (memory|cpu|mutex).
    PROFILE_PATH: Profiler output directory.
    PROFILE_DURATION: The duration (minutes) the profiler will collect data. (0=indefinitely)
```

- New logging and profiling operator variables are the following :  controller_log_level , controller_profile_kind , controller_profile_path , controller_profile_duration
- Variables have no default
- controller_log_level must be set and be of type integer to trigger an update on the controller deployment
- controller_profile_kind, controller_profile_path and controller_profile_duration must **ALL** be set to trigger an update on the controller deployment
- By default both containers in controller pod mount a Emptydir profiler volume at /var/cache/profiler (controlled by profiler_volume_path)
- Fixes #108 

Sample CR with settings applied for controller pod below : 
```
Spec:
  controller_log_level:         1
  controller_profile_duration:  60
  controller_profile_kind:      cpu
  controller_profile_path:      /var/cache/profiler
  feature_ui:                   true
  feature_validation:           true
```