### PR TITLE
Fix number test in Ansible template

### DIFF
--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -49,7 +49,7 @@ spec:
           value: "true"
         - name: SECRET_NAME
           value: webhook-server-secret
-{% if controller_log_level is defined and controller_log_level is integer %}
+{% if controller_log_level is defined and controller_log_level is number %}
         - name: LOG_LEVEL
           value: "{{ controller_log_level }}"
 {% endif %}
@@ -111,7 +111,7 @@ spec:
         - name: POLICY_AGENT_SEARCH_INTERVAL
           value: "{{ validation_policy_agent_search_interval }}"
 {% endif %}
-{% if controller_log_level is defined and controller_log_level is integer %}
+{% if controller_log_level is defined and controller_log_level is number %}
         - name: LOG_LEVEL
           value: "{{ controller_log_level }}"
 {% endif %}


### PR DESCRIPTION
Downstream operator image is based uses Jinja 2.10 that doesn't support the `integer` test. This is only available starting with 2.11. In the version 2.10, the `number` test is available, so this pull request changes the template to use it.