### PR TITLE
BZ 1963682 - Create the ForkliftController CR at install time

### DIFF
--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -12,20 +12,21 @@ metadata:
     containerImage: quay.io/konveyor/forklift-operator:latest
     createdAt: 2020-06-16T11:21:00Z
     repository: https://github.com/konveyor/forklift-operator
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "ForkliftController",
+        "metadata": {
+          "name": "forklift-controller",
+          "namespace": "konveyor-forklift"
+        },
+        "spec": {
+          "feature_ui": "true",
+          "feature_validation": "true"
+        }
+      }
     alm-examples: |-
       [
-        {
-          "apiVersion": "forklift.konveyor.io/v1beta1",
-          "kind": "ForkliftController",
-          "metadata": {
-            "name": "forklift-controller",
-            "namespace": "konveyor-forklift"
-          },
-          "spec": {
-            "feature_ui": "true",
-            "feature_validation": "true"
-          }
-        },
         {
           "apiVersion": "forklift.konveyor.io/v1beta1",
           "kind": "Migration",

--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -29,6 +29,18 @@ metadata:
       [
         {
           "apiVersion": "forklift.konveyor.io/v1beta1",
+          "kind": "ForkliftController",
+          "metadata": {
+            "name": "forklift-controller",
+            "namespace": "konveyor-forklift"
+          },
+          "spec": {
+            "feature_ui": "true",
+            "feature_validation": "true"
+          }
+        },
+        {
+          "apiVersion": "forklift.konveyor.io/v1beta1",
           "kind": "Migration",
           "metadata": {
             "name": "example-migration",

--- a/config/samples/forklift_v1beta1_forkliftcontroller.yaml
+++ b/config/samples/forklift_v1beta1_forkliftcontroller.yaml
@@ -2,3 +2,6 @@ apiVersion: forklift.konveyor.io/v1beta1
 kind: ForkliftController
 metadata:
   name: forklift-controller
+spec:
+  feature_ui: true
+  feature_validation: true


### PR DESCRIPTION
When installing Forklift, it is painful to have to create the ForkliftController CR manually, when it is actually mandatory.
This pull request adds it as an initialization custom resource [1], so that it's created during the operator installation.

[1] [OpenShift Doc > Operator > Initializing required custom resources
](https://docs.openshift.com/container-platform/4.7/operators/operator_sdk/osdk-generating-csvs.html#osdk-init-resource_osdk-generating-csvs)

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1963682