### PR TITLE
Bug 1977657 - Use ca.crt instead of service-ca.crt for UI

### DIFF
--- a/roles/forkliftcontroller/templates/deployment-ui.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-ui.yml.j2
@@ -26,7 +26,7 @@ spec:
             - name: META_FILE
               value: {{ ui_configmap_path }}/{{ ui_meta_file_name }}
             - name: NODE_EXTRA_CA_CERTS
-              value: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+              value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             - name: FORKLIFT_OPERATOR_VERSION
               value: {{ forklift_operator_version }}
             - name: FORKLIFT_CLUSTER_VERSION


### PR DESCRIPTION
This pull request is a parallel change to https://github.com/konveyor/forklift-ui/pull/680, in order to point the  `NODE_EXTRA_CA_CERTS` environment variable to `ca.crt`, instead of `service-ca.crt`.