### PR TITLE
Bug 1977657 - Set CA bundle to /opt/app-root/src/ca.crt

### DIFF
--- a/roles/forkliftcontroller/templates/deployment-ui.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-ui.yml.j2
@@ -26,7 +26,7 @@ spec:
             - name: META_FILE
               value: {{ ui_configmap_path }}/{{ ui_meta_file_name }}
             - name: NODE_EXTRA_CA_CERTS
-              value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              value: /opt/app-root/src/ca.crt
             - name: FORKLIFT_OPERATOR_VERSION
               value: {{ forklift_operator_version }}
             - name: FORKLIFT_CLUSTER_VERSION


### PR DESCRIPTION
This is a sibling pull request for https://github.com/konveyor/forklift-ui/pull/681 and points `NODE_EXTRA_CA_CERTS` to `/opt/app-root/src/ca.crt`.