### PR TITLE
GH Action: Add CSV validation

### DIFF
--- a/.github/workflows/csv-validate.yml
+++ b/.github/workflows/csv-validate.yml
@@ -1,0 +1,31 @@
+name: Validate bundle CSV
+
+on:
+  pull_request:
+    branches:
+    - main
+    - 'release-*.*.*'
+    paths:
+    - 'bundle/**'
+    workflow_dispatch:
+
+env:
+  OPERATOR_SDK_DL_URL: https://github.com/operator-framework/operator-sdk/releases/download
+  OPERATOR_SDK_VERSION: v1.8.0
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Get Operator SDK
+        run: curl -LO ${{ env.OPERATOR_SDK_DL_URL }}/${{ env.OPERATOR_SDK_VERSION }}/operator-sdk_linux_amd64 && chmod +x operator-sdk_* && mv operator-sdk_linux_amd64 operator-sdk
+
+      - name: Validate bundle
+        run: ./operator-sdk bundle validate ./bundle


### PR DESCRIPTION
This PR adds bundle validation using Operator SDK to prevent issues with malformed manifests on CSV, these are the main rules for the GH action : 

- Only pull requests to master or release-* branches will trigger this action
- Only changes in bundle/* will trigger the action
- Operator SDK version used is the same as the one that built the operator for each respective branch, needs to be updated for each branch i.e (v2.0.0 -> sdk-1.3.2 , v2.1.0 -> sdk-1.8.0)
