### PR TITLE
PR sanity: Add ansible linter GH action

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,26 @@
+name: Ansible Lint
+
+on:
+  pull_request:
+    branches:
+    - main
+    - 'release-*.*.*'
+    paths:
+    - 'roles/**'
+    workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Ansible Lint
+        uses: ansible/ansible-lint-action@master
+        with:
+          targets: |
+            ./roles/forkliftcontroller/**/*.yml
+            ./roles/forkliftcontroller/**/*.yaml


### PR DESCRIPTION
This PR adds an ansible linting GH action workflow to the operator repo, it is intended to catch issues when modifying operator roles.

- Targets main and release branches
- Gates incoming PRs that modify .yml or .yaml files in roles/
- Uses ansible-lint which is an action verified by GH