### PR TITLE
Bug: 1987479 RBAC fix for hooks

### DIFF
--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -363,6 +363,19 @@ spec:
           - secrets
           - namespaces
           - events
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
           verbs:
           - get
           - list


### PR DESCRIPTION
Adjust perms to the forklift-controller SA in order to resolve RBAC issues with hooks, see : https://bugzilla.redhat.com/show_bug.cgi?id=1987479

- Allow manipulation of configmaps
- Allow manipulation of batch/jobs 

Sample cluster role assigned to controller SA : 
```
oc describe clusterrole konveyor-forklift-operator.v99.0.0-6c5d78c585
Name:         konveyor-forklift-operator.v99.0.0-6c5d78c585
Labels:       olm.owner=konveyor-forklift-operator.v99.0.0
              olm.owner.kind=ClusterServiceVersion
              olm.owner.namespace=konveyor-forklift
              operators.coreos.com/forklift-operator.konveyor-forklift=
Annotations:  <none>
PolicyRule:
  Resources                                       Non-Resource URLs  Resource Names  Verbs
  ---------                                       -----------------  --------------  -----
  *.forklift.konveyor.io                          []                 []              [*]
  configmaps                                      []                 []              [get list watch create update patch delete]
  events                                          []                 []              [get list watch create update patch delete]
  namespaces                                      []                 []              [get list watch create update patch delete]
  secrets                                         []                 []              [get list watch create update patch delete]
  jobs.batch                                      []                 []              [get list watch create update patch delete]
  resourcemappings.v2v.kubevirt.io                []                 []              [get list watch create update patch delete]
  virtualmachineimports.v2v.kubevirt.io           []                 []              [get list watch create update patch delete]
  datavolumes.cdi.kubevirt.io                     []                 []              [get list watch]
  network-attachment-definitions.k8s.cni.cncf.io  []                 []              [get list watch]
  virtualmachines.kubevirt.io                     []                 []              [get list watch]
  storageclasses.storage.k8s.io                   []                 []              [get list watch]
```