### PR TITLE
controller pod: Set and increase default loglevel

### DIFF
--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -18,6 +18,7 @@ controller_container_limits_cpu: "500m"
 controller_container_limits_memory: "800Mi"
 controller_container_requests_cpu: "100m"
 controller_container_requests_memory: "350Mi"
+controller_log_level: 3
 profiler_volume_path: "/var/cache/profiler"
 
 validation_image_fqin: "{{ lookup( 'env', 'VALIDATION_IMAGE') }}"

--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -41,14 +41,14 @@
       state: present
       definition: "{{ lookup('template', item) }}"
     with_fileglob: "templates/provisioner-*.j2"
-      
+
   - when: feature_validation|bool
     block:
     - name: "Setup validation deployment"
       k8s:
         state : present
         definition: "{{ lookup('template', 'deployment-validation.yml.j2') }}"
-  
+
     - name: "Setup validation service"
       k8s:
         state : present


### PR DESCRIPTION
As per @jortel request , we are setting a default loglevel of 3 for the controller pod (both containers) instead of relying on 0 (unset).

Please let me know if we should pick this one for 2.1.0.