### PR TITLE
Ensure cleanups when features are disabled on CR

### DIFF
--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -2,13 +2,18 @@
 app_name: "{{ lookup('env', 'APP_NAME') or 'forklift' }}"
 app_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') or 'konveyor-forklift' }}"
 
-# Deployment features
+# Feature defaults
 feature_ui: true
 feature_validation: true
 
 k8s_cluster: false
 image_pull_policy: Always
 forklift_operator_version: "latest"
+forklift_resources:
+  - Deployment
+  - ConfigMap
+  - Service
+  - Route
 
 controller_image_fqin: "{{ lookup( 'env', 'CONTROLLER_IMAGE') }}"
 controller_configmap_name: "{{ controller_service_name }}-config"
@@ -22,14 +27,6 @@ controller_container_requests_memory: "350Mi"
 controller_log_level: 3
 profiler_volume_path: "/var/cache/profiler"
 
-validation_image_fqin: "{{ lookup( 'env', 'VALIDATION_IMAGE') }}"
-validation_service_name: "{{ app_name }}-validation"
-validation_deployment_name: "{{ validation_service_name }}"
-validation_container_name: "{{ app_name }}-validation"
-validation_policy_agent_search_interval: "120"
-validation_tls_secret_name: "{{ validation_service_name }}-serving-cert"
-validation_tls_enabled: true
-
 inventory_volume_path: "/var/cache/inventory"
 inventory_container_name: "{{ app_name }}-inventory"
 inventory_service_name: "{{ app_name }}-inventory"
@@ -40,6 +37,15 @@ inventory_container_requests_cpu: "500m"
 inventory_container_requests_memory: "500Mi"
 inventory_tls_secret_name: "{{ inventory_service_name }}-serving-cert"
 inventory_tls_enabled: true
+
+validation_image_fqin: "{{ lookup( 'env', 'VALIDATION_IMAGE') }}"
+validation_service_name: "{{ app_name }}-validation"
+validation_deployment_name: "{{ validation_service_name }}"
+validation_container_name: "{{ app_name }}-validation"
+validation_policy_agent_search_interval: "120"
+validation_tls_secret_name: "{{ validation_service_name }}-serving-cert"
+validation_tls_enabled: true
+validation_state: absent
 
 ui_image_fqin: "{{ lookup( 'env', 'UI_IMAGE') }}"
 ui_oauth_user_scope: "user:full"
@@ -56,3 +62,4 @@ ui_tls_secret_name: "{{ ui_service_name }}-serving-cert"
 ui_tls_enabled: true
 ui_route_name: "virt"
 ui_meta_file_name: "meta.json"
+ui_state: absent

--- a/roles/forkliftcontroller/tasks/cleanup.yml
+++ b/roles/forkliftcontroller/tasks/cleanup.yml
@@ -1,0 +1,22 @@
+---
+- block:
+
+  - name: "Get {{ resource_kind }} resources labeled {{ feature_label }}"
+    k8s_info:
+      namespace: "{{ app_namespace }}"
+      kind: "{{ resource_kind }}"
+      label_selectors:
+        - "service = {{ feature_label }}"
+    register: results
+
+  - name: "Clean up {{ resource_kind }} labeled {{ feature_label }}"
+    k8s:
+      namespace: "{{ app_namespace }}"
+      kind: "{{ results.resources[0].kind }}"
+      name: "{{ results.resources[0].metadata.name }}"
+      state: absent
+    when: (results.resources|length) > 0
+
+  rescue:
+  - debug:
+      msg: "Something went wrong, ignoring empty or missing resources for {{ resource_kind }} label {{ feature_label }}"

--- a/roles/forkliftcontroller/tasks/cleanup.yml
+++ b/roles/forkliftcontroller/tasks/cleanup.yml
@@ -9,7 +9,7 @@
         - "service = {{ feature_label }}"
     register: results
 
-  - name: "Clean up {{ resource_kind }} labeled {{ feature_label }}"
+  - name: "Clean up {{ resource_kind }} resources labeled {{ feature_label }}"
     k8s:
       namespace: "{{ app_namespace }}"
       kind: "{{ results.resources[0].kind }}"

--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -1,6 +1,16 @@
 ---
 - block:
 
+  - name: "Set UI feature state"
+    set_fact:
+      ui_state: "present"
+    when: feature_ui|bool
+
+  - name: "Set validation feature state"
+    set_fact:
+      validation_state: "present"
+    when: feature_validation|bool
+
   - name: "Load cluster API groups"
     set_fact:
       api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
@@ -47,7 +57,7 @@
       definition: "{{ lookup('template', 'provider-host.yml.j2') }}"
     when: "'kubevirt.io' in api_groups"
 
-  - name: "Installing the Provisioner CR"
+  - name: "Installing the provisioner CR"
     k8s:
       state: present
       definition: "{{ lookup('template', item) }}"
@@ -57,12 +67,12 @@
     block:
     - name: "Setup validation service"
       k8s:
-        state : present
+        state : "{{ validation_state }}"
         definition: "{{ lookup('template', 'service-validation.yml.j2') }}"
 
     - name: "Setup validation deployment"
       k8s:
-        state : present
+        state : "{{ validation_state }}"
         definition: "{{ lookup('template', 'deployment-validation.yml.j2') }}"
 
   - when: feature_ui|bool and not k8s_cluster|bool
@@ -100,7 +110,7 @@
       block:
       - name: "Setup UI route"
         k8s:
-          state: present
+          state: "{{ ui_state }}"
           definition: "{{ lookup('template', 'route-ui.yml.j2') }}"
 
       - name: "Obtain UI route (timeout 60s)"
@@ -133,15 +143,33 @@
 
     - name: "Setup UI config map"
       k8s:
-        state: present
+        state: "{{ ui_state }}"
         definition: "{{ lookup('template', 'configmap-ui.yml.j2') }}"
 
     - name: "Setup UI service"
       k8s:
-        state: present
+        state: "{{ ui_state }}"
         definition: "{{ lookup('template', 'service-ui.yml.j2') }}"
 
     - name: "Setup UI deployment"
       k8s:
-        state: present
+        state: "{{ ui_state }}"
         definition: "{{ lookup('template', 'deployment-ui.yml.j2') }}"
+
+  - when: not feature_ui|bool
+    name: "Cleanup {{ ui_service_name }} if disabled"
+    include_tasks: cleanup.yml
+    loop: "{{ forklift_resources }}"
+    loop_control:
+      loop_var: resource_kind
+    vars:
+      feature_label: "{{ ui_service_name }}"
+
+  - when: not feature_validation|bool
+    name: "Cleanup {{ validation_service_name }} if disabled"
+    include_tasks: cleanup.yml
+    loop: "{{ forklift_resources }}"
+    loop_control:
+      loop_var: resource_kind
+    vars:
+      feature_label: "{{ validation_service_name }}"


### PR DESCRIPTION
This PR will ensure we perform cleanups when a particular feature is disabled after initial deployment. Fixes #151 .

- Use state variables to reconcile for features (ui_state , validation_state)
- Implement re-usable cleanup.yml which gets resources by label and removes them