### PR TITLE
Rename controller container

### DIFF
--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -26,7 +26,7 @@ spec:
     spec:
       serviceAccountName: {{ controller_service_name }}
       containers:
-      - name: controller
+      - name: main
         command:
         - /usr/local/bin/manager
         env:


### PR DESCRIPTION
As requested by @jortel , controller container renamed to main on controller pod.
