### PR TITLE
Add must-gather-api service

### DIFF
--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -165,10 +165,16 @@ spec:
   relatedImages:
   - name: controller
     image: quay.io/konveyor/forklift-controller:latest
+  - name: must-gather
+    image: quay.io/konveyor/forklift-must-gather:latest
+  - name: must-gather-api
+    image: quay.io/konveyor/forklift-must-gather-api:latest
   - name: ui
     image: quay.io/konveyor/forklift-ui:latest
   - name: validation
     image: quay.io/konveyor/forklift-validation:latest
+  - name: virt-v2v
+    image: quay.io/konveyor/forklift-virt-v2v:latest
   displayName: Konveyor Forklift Operator
   description: |+
     The Konveyor Forklift Operator fully manages the deployment and life cycle of Forklift on [OpenShift](https://www.openshift.com/).
@@ -181,6 +187,7 @@ spec:
     * controller, to coordinate migration processes.
     * ui, the web console to manage migrations.
     * validation, to validate migration workflows.
+    * must-gather-api, a service to generate targeted must-gather archives.
 
     ### Documentation
     Documentation can be found on our [website](https://forklift-docs.konveyor.io).
@@ -229,10 +236,16 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: CONTROLLER_IMAGE
                   value: quay.io/konveyor/forklift-controller:latest
+                - name: MUST_GATHER_IMAGE
+                  value: quay.io/konveyor/forklift-must-gather:latest
+                - name: MUST_GATHER_API_IMAGE
+                  value: quay.io/konveyor/forklift-must-gather-api:latest
                 - name: UI_IMAGE
                   value: quay.io/konveyor/forklift-ui:latest
                 - name: VALIDATION_IMAGE
                   value: quay.io/konveyor/forklift-validation:latest
+                - name: VIRT_V2V_IMAGE
+                  value: quay.io/konveyor/forklift-virt-v2v:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -23,6 +23,7 @@ metadata:
         "spec": {
           "feature_ui": "true",
           "feature_validation": "true"
+          "feature_must_gather_api": "true"
         }
       }
     alm-examples: |-

--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -5,6 +5,7 @@ app_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') or 'konveyor-forklift' }}"
 # Feature defaults
 feature_ui: true
 feature_validation: true
+feature_must_gather_api: true
 
 k8s_cluster: false
 image_pull_policy: Always
@@ -63,3 +64,12 @@ ui_tls_enabled: true
 ui_route_name: "virt"
 ui_meta_file_name: "meta.json"
 ui_state: absent
+
+must_gather_api_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_API_IMAGE') }}"
+must_gather_api_service_name: "{{ app_name }}-must-gather-api"
+must_gather_api_deployment_name: "{{ must_gather_api_service_name }}"
+must_gather_api_container_name: "{{ app_name }}-must-gather-api"
+must_gather_api_tls_secret_name: "{{ must_gather_api_service_name }}-serving-cert"
+must_gather_api_tls_enabled: true
+must_gather_api_state: absent
+

--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -11,6 +11,11 @@
       validation_state: "present"
     when: feature_validation|bool
 
+  - name: "Set must-gather-api feature state"
+    set_fact:
+      must_gather_api_state: "present"
+    when: feature_must_gather_api|bool
+
   - name: "Load cluster API groups"
     set_fact:
       api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
@@ -74,6 +79,18 @@
       k8s:
         state : "{{ validation_state }}"
         definition: "{{ lookup('template', 'deployment-validation.yml.j2') }}"
+
+  - when: feature_must_gather_api|bool
+    block:
+    - name: "Setup must-gather-api service"
+      k8s:
+        state : "{{ must_gather_api_state }}"
+        definition: "{{ lookup('template', 'service-must-gather-api.yml.j2') }}"
+
+    - name: "Setup must-gather-api deployment"
+      k8s:
+        state : "{{ must-gather-api_state }}"
+        definition: "{{ lookup('template', 'deployment-must-gather-api.yml.j2') }}"
 
   # Non-k8s UI tasks
   - when: feature_ui|bool and not k8s_cluster|bool
@@ -171,3 +188,13 @@
       loop_var: resource_kind
     vars:
       feature_label: "{{ validation_service_name }}"
+
+  - when: not feature_must_gather_api|bool
+    name: "Cleanup {{ must_gather_api_service_name }} if disabled"
+    include_tasks: cleanup.yml
+    loop: "{{ forklift_resources }}"
+    loop_control:
+      loop_var: resource_kind
+    vars:
+      feature_label: "{{ must_gather_api_service_name }}"
+

--- a/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
@@ -1,0 +1,72 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ must_gather_api_deployment_name }}
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+    service: {{ must_gather_api_service_name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ app_name }}
+      service: {{ must_gather_api_service_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ app_name }}
+        service: {{ must_gather_api_service_name }}
+    spec:
+      containers:
+        - name: {{ must_gather_api_container_name }}
+          image: {{ must_gather_api_image_fqin }}
+          imagePullPolicy: {{ image_pull_policy }}
+          ports:
+{% if inventory_tls_enabled|bool %}
+          - name: api
+            containerPort: 8443
+            protocol: TCP
+{% else %}
+          - name: api
+            containerPort: 8080
+            protocol: TCP
+{% endif %}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: METRICS_PORT
+              value: 8081
+{% if must_gather_api_tls_enabled|bool %}
+            - name: API_PORT
+              value: 8080
+            - name: TLS_ENABLED
+              value: 'true'
+            - name: TLS_CERT_FILE
+              value: /var/run/secrets/{{ must_gather_api_tls_secret_name }}/tls.crt
+            - name: TLS_KEY_FILE
+              value: /var/run/secrets/{{ must_gather_api_tls_secret_name }}/tls.key
+            - name: CA_TLS_CERTIFICATE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+{% else %}
+            - name: API_PORT
+              value: 8443
+            - name: TLS_ENABLED
+              value: 'false'
+{% endif %}
+          volumeMounts:
+{% if must_gather_api_tls_enabled|bool %}
+            - name: {{ must_gather_api_tls_secret_name }}
+              mountPath: /var/run/secrets/{{ must_gather_api_tls_secret_name }}
+{% endif %}
+      volumes:
+{% if must_gather_api_tls_enabled|bool %}
+        - name: {{ must_gather_api_tls_secret_name }}
+          secret:
+            secretName: {{ must_gather_api_tls_secret_name }}
+            defaultMode: 420
+{% endif %}

--- a/roles/forkliftcontroller/templates/service-must-gather-api.yml.j2
+++ b/roles/forkliftcontroller/templates/service-must-gather-api.yml.j2
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ must_gather_api_tls_secret_name }}
+  name: {{ must_gather_api_service_name }}
+  namespace: "{{ app_namespace }}"
+  labels:
+    app: {{ app_name }}
+    service: {{ must_gather_api_service_name }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ app_name }}
+    service: {{ must_gather_api_service_name }}
+  ports:
+{% if inventory_tls_enabled|bool %}
+  - name: api-https
+    port: 8443
+    targetPort: 8443
+    protocol: TCP
+{% else %}
+  - name: api-http
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+{% endif %}
+


### PR DESCRIPTION
The must-gather-api service exposes an API to trigger a must-gather collection, with a target namespace, plan, VM if needed.
This pull request adds the deployment and service to the role. It also updates the CSV to list must-gather-api and virt-v2v images.