### PR TITLE
Minor fixes for must-gather-api service

### DIFF
--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
         },
         "spec": {
           "feature_ui": "true",
-          "feature_validation": "true"
+          "feature_validation": "true",
           "feature_must_gather_api": "true"
         }
       }

--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -70,6 +70,7 @@ must_gather_api_service_name: "{{ app_name }}-must-gather-api"
 must_gather_api_deployment_name: "{{ must_gather_api_service_name }}"
 must_gather_api_container_name: "{{ app_name }}-must-gather-api"
 must_gather_api_tls_secret_name: "{{ must_gather_api_service_name }}-serving-cert"
-must_gather_api_tls_enabled: true
+must_gather_api_tls_enabled: false
+must_gather_api_db_path: "/tmp/gatherings.db"
+must_gather_api_cleanup_max_age: "-1"
 must_gather_api_state: absent
-

--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -72,24 +72,24 @@
     block:
     - name: "Setup validation service"
       k8s:
-        state : "{{ validation_state }}"
+        state: "{{ validation_state }}"
         definition: "{{ lookup('template', 'service-validation.yml.j2') }}"
 
     - name: "Setup validation deployment"
       k8s:
-        state : "{{ validation_state }}"
+        state: "{{ validation_state }}"
         definition: "{{ lookup('template', 'deployment-validation.yml.j2') }}"
 
   - when: feature_must_gather_api|bool
     block:
     - name: "Setup must-gather-api service"
       k8s:
-        state : "{{ must_gather_api_state }}"
+        state: "{{ must_gather_api_state }}"
         definition: "{{ lookup('template', 'service-must-gather-api.yml.j2') }}"
 
     - name: "Setup must-gather-api deployment"
       k8s:
-        state : "{{ must-gather-api_state }}"
+        state: "{{ must_gather_api_state }}"
         definition: "{{ lookup('template', 'deployment-must-gather-api.yml.j2') }}"
 
   # Non-k8s UI tasks

--- a/roles/forkliftcontroller/templates/configmap-ui.yml.j2
+++ b/roles/forkliftcontroller/templates/configmap-ui.yml.j2
@@ -18,6 +18,11 @@ data:
 {% else %}
       "inventoryApi": "http://{{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local:8080",
 {% endif %}
+{% if must_gather_api_tls_enabled|bool %}
+      "mustGatherApi": "https://{{ must_gather_api_service_name }}.{{ app_namespace }}.svc.cluster.local:8443",
+{% else %}
+      "mustGatherApi": "http://{{ must_gather_api_service_name }}.{{ app_namespace }}.svc.cluster.local:8080",
+{% endif %}
       "oauth": {
 {% if not k8s_cluster|bool %}
         "clientId": "{{ ui_service_name }}",

--- a/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
@@ -24,7 +24,7 @@ spec:
           image: {{ must_gather_api_image_fqin }}
           imagePullPolicy: {{ image_pull_policy }}
           ports:
-{% if inventory_tls_enabled|bool %}
+{% if must_gather_api_tls_enabled|bool %}
           - name: api
             containerPort: 8443
             protocol: TCP
@@ -39,24 +39,20 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-            - name: METRICS_PORT
-              value: 8081
 {% if must_gather_api_tls_enabled|bool %}
-            - name: API_PORT
-              value: 8080
-            - name: TLS_ENABLED
-              value: 'true'
-            - name: TLS_CERT_FILE
-              value: /var/run/secrets/{{ must_gather_api_tls_secret_name }}/tls.crt
-            - name: TLS_KEY_FILE
-              value: /var/run/secrets/{{ must_gather_api_tls_secret_name }}/tls.key
-            - name: CA_TLS_CERTIFICATE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+            - name: PORT
+              value: "8443"
+            - name: DB_PATH
+              value: {{ must_gather_api_db_path }}
+            - name: CLEANUP_MAX_AGE
+              value: "{{ must_gather_api_cleanup_max_age }}"
 {% else %}
-            - name: API_PORT
-              value: 8443
-            - name: TLS_ENABLED
-              value: 'false'
+            - name: PORT
+              value: "8080"
+            - name: DB_PATH
+              value: {{ must_gather_api_db_path }}
+            - name: CLEANUP_MAX_AGE
+              value: "{{ must_gather_api_cleanup_max_age }}"
 {% endif %}
           volumeMounts:
 {% if must_gather_api_tls_enabled|bool %}

--- a/roles/forkliftcontroller/templates/service-must-gather-api.yml.j2
+++ b/roles/forkliftcontroller/templates/service-must-gather-api.yml.j2
@@ -15,7 +15,7 @@ spec:
     app: {{ app_name }}
     service: {{ must_gather_api_service_name }}
   ports:
-{% if inventory_tls_enabled|bool %}
+{% if must_gather_api_tls_enabled|bool %}
   - name: api-https
     port: 8443
     targetPort: 8443
@@ -26,4 +26,3 @@ spec:
     targetPort: 8080
     protocol: TCP
 {% endif %}
-


### PR DESCRIPTION
- Cleaned up TLS (disabled by default since GIN gonic needs extra work)
- Use appropiate environment GIN gonic vars for settings
- JSON typo on ALM bundle examples
- Added UI mustGatherApi info to UI configmap
- Other minor syntax issues
- Validated feature cleanup tasks

Tested on OCP v4.9

```
oc logs forklift-must-gather-api-6598bf779f-q5bj5
2021/09/15 18:18:59 Config option DB_PATH set from environment variable to: /tmp/gatherings.db
[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.

[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:	export GIN_MODE=release
 - using code:	gin.SetMode(gin.ReleaseMode)

2021/09/15 18:18:59 Config option CLEANUP_MAX_AGE set from environment variable to: -1
[GIN-debug] GET    /                         --> main.setupRouter.func1 (3 handlers)
[GIN-debug] POST   /must-gather              --> main.triggerGathering (3 handlers)
[GIN-debug] GET    /must-gather              --> main.listGatherings (3 handlers)
[GIN-debug] GET    /must-gather/:id          --> main.getGathering (3 handlers)
[GIN-debug] GET    /must-gather/:id/data     --> main.getGatheringArchive (3 handlers)
[GIN-debug] Environment variable PORT="8080"
[GIN-debug] Listening and serving HTTP on :8080
2021/09/15 18:18:59 Periodical must-gather executions cleanup is disabled.
```