### PR TITLE
Pass the VIRT_V2V_IMAGE variable to the controller container

### DIFF
--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -74,3 +74,5 @@ must_gather_api_tls_enabled: false
 must_gather_api_db_path: "/tmp/gatherings.db"
 must_gather_api_cleanup_max_age: "-1"
 must_gather_api_state: absent
+
+virt_v2v_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_IMAGE') }}"

--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -40,6 +40,8 @@ spec:
           value: {{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local
         - name: KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION
           value: "v1"
+        - name: VIRT_V2V_IMAGE
+          value: {{ virt_v2v_image_fqin }}
 {% if inventory_tls_enabled|bool %}
         - name: API_PORT
           value: "8443"


### PR DESCRIPTION
The name of the image used to run virt-v2v is set by default to `quay.io/konveyor/forklift-virt-v2v:latest`.
This pull request allows to set it via an environment variable. And the user can set it via an extra var.

Signed-off-by: Fabien Dupont <fdupont@redhat.com>