### PR TITLE
Add validation service resource constrains

### DIFF
--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -47,6 +47,10 @@ validation_container_name: "{{ app_name }}-validation"
 validation_extra_volume_name: "validation-extra-rules"
 validation_extra_volume_mountpath: "/usr/share/opa/policies/extra"
 validation_policy_agent_search_interval: "120"
+validation_container_limits_cpu: "1000m"
+validation_container_limits_memory: "300Mi"
+validation_container_requests_cpu: "400m"
+validation_container_requests_memory: "50Mi"
 validation_tls_secret_name: "{{ validation_service_name }}-serving-cert"
 validation_tls_enabled: true
 validation_state: absent

--- a/roles/forkliftcontroller/templates/deployment-validation.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-validation.yml.j2
@@ -26,6 +26,13 @@ spec:
           ports:
             - name: opa
               containerPort: 8181
+          resources:
+            limits:
+              cpu: {{ validation_container_limits_cpu }}
+              memory: {{ validation_container_limits_memory }}
+            requests:
+              cpu: {{ validation_container_requests_cpu }}
+              memory: {{ validation_container_requests_memory }}
           env:
             - name: POD_NAMESPACE
               valueFrom:


### PR DESCRIPTION
Add missing validation service constrains , resource consumption sample taken from a QE cluster with a migration load. Fixes #168 