### PR TITLE
Add Branch-to-Release reference map file

### DIFF
--- a/docs/MTV_BZ_MAP.md
+++ b/docs/MTV_BZ_MAP.md
@@ -1,6 +1,6 @@
 # Forklift/MTV Branch-to-Release Map
 
-This is the value last set in Konveyor's [BRANCH_TO_RELEASE](https://github.com/organizations/konveyor/settings/secrets/actions/BRANCH_TO_RELEASE) secret.
+This is the value last set in Konveyor's [MTV_PR_BZ_MAP](https://github.com/organizations/konveyor/settings/secrets/actions/MTV_PR_BZ_MAP) secret.
 
 ```
 'release-v2.0.0:2.0.0,release-v2.1.0:2.1.0,release-v2.2.0:2.2.0,main:2.3.0'


### PR DESCRIPTION
This is the reference map that should be updated and kept in sync with our mappings secret for BZ GH action. Updated for release-v2.2.0. See also : https://github.com/konveyor/bz-github-action/issues/10
