### PR TITLE
Bug 2012564: Sync CRDs with #179

### DIFF
--- a/bundle/manifests/forklift.konveyor.io_migrations.yaml
+++ b/bundle/manifests/forklift.konveyor.io_migrations.yaml
@@ -430,7 +430,6 @@ spec:
                   required:
                   - phase
                   - pipeline
-                  - restorePowerState
                   type: object
                 type: array
             type: object

--- a/bundle/manifests/forklift.konveyor.io_plans.yaml
+++ b/bundle/manifests/forklift.konveyor.io_plans.yaml
@@ -771,7 +771,6 @@ spec:
                       required:
                       - phase
                       - pipeline
-                      - restorePowerState
                       type: object
                     type: array
                 type: object


### PR DESCRIPTION
- Remove requirement for restorePowerState in migrations and plans CRDs