### PR TITLE
Change controller k8s module call to non-default merge type

### DIFF
--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -49,6 +49,7 @@
     k8s:
       state : present
       definition: "{{ lookup('template', 'deployment-controller.yml.j2') }}"
+      merge_type: "merge"
 
   - name: "Setup inventory route"
     k8s:


### PR DESCRIPTION
This PR attempts to rectify issues when upgrading controller from previous releases where the default k8s merge type (stragegic_merge) causes an append to the controller deployment resource instead of updating. This has surfaced via #154 , the symptoms are that the controller pod starts 3 containers (controller, main and inventory) instead of 2 causing resource constrains and further failures.
I'm only targeting the controller deployment since we need more validation to ensure that it is safe and does not introduce side effects or issues.