### PR TITLE
Bug 2024153: Make PRECOPY_INTERVAL a managed setting in operator

### DIFF
--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -26,6 +26,7 @@ controller_container_limits_memory: "800Mi"
 controller_container_requests_cpu: "100m"
 controller_container_requests_memory: "350Mi"
 controller_log_level: 3
+controller_precopy_interval: 60
 profiler_volume_path: "/var/cache/profiler"
 
 inventory_volume_path: "/var/cache/inventory"

--- a/roles/forkliftcontroller/templates/configmap-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/configmap-controller.yml.j2
@@ -11,3 +11,6 @@ metadata:
   namespace: {{ app_namespace }}
 data:
   WORKING_DIR: {{ inventory_volume_path }}
+{% if controller_precopy_interval is number %}
+  PRECOPY_INTERVAL: "{{ controller_precopy_interval }}"
+{% endif %}

--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -61,6 +61,10 @@ spec:
         - name: LOG_LEVEL
           value: "{{ controller_log_level }}"
 {% endif %}
+{% if controller_precopy_interval is number %}
+        - name: PRECOPY_INTERVAL
+          value: "{{ controller_precopy_interval }}"
+{% endif %}
 {% if controller_profile_kind is defined and controller_profile_path is defined and controller_profile_duration is defined %}
         - name: PROFILE_KIND
           value: "{{ controller_profile_kind }}"


### PR DESCRIPTION
This PR makes PRECOPY_INTERVAL a managed operator setting: 

* controller_precopy_interval is the controlling forkliftcontrollers spec variable with a default setting of 60
* controller_precopy_interval is injected into the main container in the controller pod
* controller_precopy_interval value must be an integer
* For the sake of consistency, the forklift-controller configmap is also configured with the same controller_precopy_interval , we want to avoid a user mistakenly setting different values (deployment vs configmap)

Sample forkliftcontrollers CR setting below : 

```
Spec:
  controller_precopy_interval: 3
  feature_ui:                   true
  feature_validation:           true
```