### PR TITLE
Bug 1942651: Enable vSphere incremental backup by default

### DIFF
--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -6,6 +6,7 @@ app_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') or 'konveyor-forklift' }}"
 feature_ui: true
 feature_validation: true
 feature_must_gather_api: true
+feature_vsphere_incremental_backup: true
 
 k8s_cluster: false
 image_pull_policy: Always

--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -6,7 +6,6 @@ app_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') or 'konveyor-forklift' }}"
 feature_ui: true
 feature_validation: true
 feature_must_gather_api: true
-feature_vsphere_incremental_backup: true
 
 k8s_cluster: false
 image_pull_policy: Always
@@ -28,6 +27,7 @@ controller_container_requests_cpu: "100m"
 controller_container_requests_memory: "350Mi"
 controller_log_level: 3
 controller_precopy_interval: 60
+controller_vsphere_incremental_backup: true
 profiler_volume_path: "/var/cache/profiler"
 
 inventory_volume_path: "/var/cache/inventory"

--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -65,6 +65,10 @@ spec:
         - name: PRECOPY_INTERVAL
           value: "{{ controller_precopy_interval }}"
 {% endif %}
+{% if feature_vsphere_incremental_backup|bool %}
+        - name: FEATURE_VSPHERE_INCREMENTAL_BACKUP
+          value: "true"
+{% endif %}
 {% if controller_profile_kind is defined and controller_profile_path is defined and controller_profile_duration is defined %}
         - name: PROFILE_KIND
           value: "{{ controller_profile_kind }}"

--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -65,7 +65,7 @@ spec:
         - name: PRECOPY_INTERVAL
           value: "{{ controller_precopy_interval }}"
 {% endif %}
-{% if feature_vsphere_incremental_backup|bool %}
+{% if controller_vsphere_incremental_backup|bool %}
         - name: FEATURE_VSPHERE_INCREMENTAL_BACKUP
           value: "true"
 {% endif %}


### PR DESCRIPTION
https://github.com/konveyor/forklift-controller/pull/356 adds the ability to use Change IDs for warm migration, hence to not retain snapshots during warm migration. This feature is disabled by default in the controller, so this pull request enables it by default at the operator level.