### PR TITLE
Revert "Bug 1942651: Make the boolean controller specific"

### DIFF
--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -27,7 +27,6 @@ controller_container_requests_cpu: "100m"
 controller_container_requests_memory: "350Mi"
 controller_log_level: 3
 controller_precopy_interval: 60
-controller_vsphere_incremental_backup: true
 profiler_volume_path: "/var/cache/profiler"
 
 inventory_volume_path: "/var/cache/inventory"

--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -65,10 +65,6 @@ spec:
         - name: PRECOPY_INTERVAL
           value: "{{ controller_precopy_interval }}"
 {% endif %}
-{% if controller_vsphere_incremental_backup|bool %}
-        - name: FEATURE_VSPHERE_INCREMENTAL_BACKUP
-          value: "true"
-{% endif %}
 {% if controller_profile_kind is defined and controller_profile_path is defined and controller_profile_duration is defined %}
         - name: PROFILE_KIND
           value: "{{ controller_profile_kind }}"


### PR DESCRIPTION
Reverts konveyor/forklift-operator#187
This change is causing warm migration to fail. Reverting to allow testing other features.