### PR TITLE
Use must gather image envvar

### DIFF
--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -88,4 +88,5 @@ must_gather_api_db_path: "/tmp/gatherings.db"
 must_gather_api_cleanup_max_age: "-1"
 must_gather_api_state: absent
 
+must_gather_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_IMAGE') }}"
 virt_v2v_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_IMAGE') }}"

--- a/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
@@ -48,20 +48,18 @@ spec:
               value: "/var/run/secrets/{{ must_gather_api_tls_secret_name }}/tls.crt"
             - name: API_TLS_KEY
               value: "/var/run/secrets/{{ must_gather_api_tls_secret_name }}/tls.key"
-            - name: DB_PATH
-              value: "{{ must_gather_api_db_path }}"
-            - name: CLEANUP_MAX_AGE
-              value: "{{ must_gather_api_cleanup_max_age }}"
 {% else %}
             - name: PORT
               value: "8080"
             - API_TLS_ENABLED
               value: "false"
+{% endif %}
             - name: DB_PATH
               value: "{{ must_gather_api_db_path }}"
             - name: CLEANUP_MAX_AGE
               value: "{{ must_gather_api_cleanup_max_age }}"
-{% endif %}
+            - name: DEFAULT_IMAGE
+              value: "{{ must_gather_image_fqin }}"
           resources:
             limits:
               cpu: {{ must_gather_api_container_limits_cpu }}


### PR DESCRIPTION
We have noticed that the must-gather image used in v2.2.0 deployments is `quay.io/konveyor/forklift-must-gather:latest`, while it should be the image tagged with `release-v2.2.0`. This is because the `DEFAULT_IMAGE` environment is not set on the `forklift-must-gather-api` deployment.

This pull request sets the environment to `MUST_GATHER_IMAGE`, itself set in the CSV to the tag matching the release.

It also deduplicates a section of the deployment template.