### PR TITLE
Replace DEFAULT_IMAGE with MUST_GATHER_IMAGE

### DIFF
--- a/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
@@ -58,7 +58,7 @@ spec:
               value: "{{ must_gather_api_db_path }}"
             - name: CLEANUP_MAX_AGE
               value: "{{ must_gather_api_cleanup_max_age }}"
-            - name: DEFAULT_IMAGE
+            - name: MUST_GATHER_IMAGE
               value: "{{ must_gather_image_fqin }}"
           resources:
             limits:


### PR DESCRIPTION
With https://github.com/konveyor/forklift-must-gather-api/pull/18, the variable `DEFAULT_IMAGE` has been renamed to `MUST_GATHER_IMAGE`. This pull request adjusts the must-gather-api deployment.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>