### PR TITLE
Bug 2026702: Do not override controller and validation service configmaps

### DIFF
--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -35,7 +35,16 @@
       state: present
       definition: "{{ lookup('template', 'secret-webhook-server-secret.yml.j2') }}"
 
-  - name: "Setup controller config map"
+  - name: "Check if controller configMap exists already so we don't update it"
+    k8s_info:
+      api_version: v1
+      kind: ConfigMap
+      name: "{{ controller_configmap_name }}"
+      namespace: "{{ app_namespace }}"
+    register: controller_configmap_status
+
+  - when: (controller_configmap_status.resources | length) == 0
+    name: "Setup controller config map"
     k8s:
       state : present
       definition: "{{ lookup('template', 'configmap-controller.yml.j2') }}"
@@ -76,7 +85,16 @@
         state: "{{ validation_state }}"
         definition: "{{ lookup('template', 'service-validation.yml.j2') }}"
 
-    - name: "Add validation configMap"
+    - name: "Check if validation service configMap exists already so we don't update it"
+      k8s_info:
+        api_version: v1
+        kind: ConfigMap
+        name: "{{ validation_configmap_name }}"
+        namespace: "{{ app_namespace }}"
+      register: validation_configmap_status
+
+    - when: (validation_configmap_status.resources | length) == 0
+      name: "Add validation configMap"
       k8s:
         state: "{{ validation_state }}"
         definition: "{{ lookup('template', 'configmap-validation.yml.j2') }}"


### PR DESCRIPTION
We have seen cases where the validation service configmap data was emptied. We suspect that the operator role overrides the data. According to the k8s module documentation, a strategic merge is done and it _should_ retain the files listed in `.data`. Observation in the field is different.

This pull request checks the presence of the controller and validation service configmaps and skips the configmap creation/update if it exists. This should avoid any risk of the operator overriding them when they contain user data.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>