### PR TITLE
Allow setting debug mode for must-gather-api

### DIFF
--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -86,6 +86,7 @@ must_gather_api_tls_secret_name: "{{ must_gather_api_service_name }}-serving-cer
 must_gather_api_tls_enabled: true
 must_gather_api_db_path: "/tmp/gatherings.db"
 must_gather_api_cleanup_max_age: "-1"
+must_gather_api_debug: false
 must_gather_api_state: absent
 
 must_gather_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_IMAGE') }}"

--- a/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
@@ -60,6 +60,10 @@ spec:
               value: "{{ must_gather_api_cleanup_max_age }}"
             - name: MUST_GATHER_IMAGE
               value: "{{ must_gather_image_fqin }}"
+{% if must_gather_api_debug|bool %}
+            - name: DEBUG
+              value: "true"
+{% endif %}
           resources:
             limits:
               cpu: {{ must_gather_api_container_limits_cpu }}


### PR DESCRIPTION
The must-gather-api service can generate debug messages
when the `DEBUG` environment variable is set to `'true'`.
This change allows setting the `must_gather_api_debug`
boolean on the ForkliftController CR to enable debug
mode. The default value is `'false'` to reduce potential
load on the pod.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>