### PR TITLE
Bug 1994179: Add support for custom ingress CA chain in OpenShift

### DIFF
--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -30,6 +30,23 @@
       set_fact:
         k8s_cluster_version: "{{ lookup('k8s', cluster_info='version').kubernetes.gitVersion }}"
 
+  - when: not k8s_cluster|bool
+    block:
+    - name: "Get cluster proxy object"
+      set_fact:
+        proxy_cluster: "{{ lookup('k8s', api_version='config.openshift.io/v1', kind='Proxy', resource_name='cluster') }}"
+
+    - when: proxy_cluster.spec.trustedCA.name|length > 0
+      block:
+      - name: "Enable trusted_ca environment"
+        set_fact:
+          trusted_ca_enabled: true
+
+      - name: "Create an empty ConfigMap that will hold the trusted CA"
+        k8s:
+          state: present
+          definition: "{{ lookup('template', 'configmap-trusted-ca.yml.j2') }}"
+
   - name: "Setup the webhook secret"
     k8s:
       state: present

--- a/roles/forkliftcontroller/templates/configmap-trusted-ca.yml.j2
+++ b/roles/forkliftcontroller/templates/configmap-trusted-ca.yml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+  annotations:
+    config.openshift.io/inject-trusted-cabundle: 'true'

--- a/roles/forkliftcontroller/templates/deployment-ui.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-ui.yml.j2
@@ -68,6 +68,11 @@ spec:
             - name: "{{ ui_tls_secret_name }}"
               mountPath: "/var/run/secrets/{{ ui_tls_secret_name }}"
 {% endif %}
+{% if trusted_ca_enabled|bool %}
+            - name: trusted-ca
+              mountPath: /etc/pki/ca-trust/extracted/pem
+              readOnly: true
+{% endif %}
       volumes:
         - name: "{{ ui_configmap_name }}"
           configMap:
@@ -77,4 +82,12 @@ spec:
           secret:
             defaultMode: 420
             secretName: "{{ ui_tls_secret_name }}"
+{% endif %}
+{% if trusted_ca_enabled|bool %}
+        - name: trusted-ca
+          configMap:
+            name: trusted-ca
+            items:
+              - key: ca-bundle.crt
+                path: tls-ca-bundle.pem
 {% endif %}


### PR DESCRIPTION
In OpenShift, it is possible to configure a custom certificate for the ingress routes. The full CA chain is provided to allow certificate verification. By default, the custom CA chain is not exposed in `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`, so pods cannot
reach services on their external URL.

The UI uses a callback link with the external URL of the UI, since it will then be passed to the user's browser that can only access external URLs. This forbids the access to the UI when using custom CA.

This change applies the OpenShift documentation [1] to mount the custom CA certificate merged with the other internal CA certificates in the UI pod. This is done by creating an empty ConfigMap annotated with `config.openshift.io/inject-trusted-cabundle="true"` and mounting this ConfigMap in the UI pod.

We also need to update the forklift-ui entrypoint to merge the service service CA certificate with the merged CA bundle into `/opt/app-root/src/ca.crt`.

[1] https://docs.openshift.com/container-platform/4.9/networking/configuring-a-custom-pki.html

Signed-off-by: fabiendupont@pm.me
Refs: RHBZ#1994179