### PR TITLE
RBAC: Allow access to proxies resource, related to #201

### DIFF
--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -284,7 +284,7 @@ spec:
                     port: 6789
                   initialDelaySeconds: 5
                   periodSeconds: 10
-                image: quay.io/fbladilo/forklift-operator:latest
+                image: quay.io/konveyor/forklift-operator:latest
                 imagePullPolicy: Always
                 name: forklift-operator
                 resources: {}

--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -284,7 +284,7 @@ spec:
                     port: 6789
                   initialDelaySeconds: 5
                   periodSeconds: 10
-                image: quay.io/konveyor/forklift-operator:latest
+                image: quay.io/fbladilo/forklift-operator:latest
                 imagePullPolicy: Always
                 name: forklift-operator
                 resources: {}
@@ -359,6 +359,7 @@ spec:
           - config.openshift.io
           resources:
           - clusterversions
+          - proxies
           verbs:
           - get
         - apiGroups:

--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -38,7 +38,7 @@
 
     - when: proxy_cluster.spec.trustedCA.name|length > 0
       block:
-      - name: "Enable trusted_ca environment"
+      - name: "Enable trusted CA environment"
         set_fact:
           trusted_ca_enabled: true
 

--- a/roles/forkliftcontroller/templates/deployment-ui.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-ui.yml.j2
@@ -68,7 +68,7 @@ spec:
             - name: "{{ ui_tls_secret_name }}"
               mountPath: "/var/run/secrets/{{ ui_tls_secret_name }}"
 {% endif %}
-{% if trusted_ca_enabled|bool %}
+{% if trusted_ca_enabled is defined and trusted_ca_enabled|bool %}
             - name: trusted-ca
               mountPath: /etc/pki/ca-trust/extracted/pem
               readOnly: true
@@ -83,7 +83,7 @@ spec:
             defaultMode: 420
             secretName: "{{ ui_tls_secret_name }}"
 {% endif %}
-{% if trusted_ca_enabled|bool %}
+{% if trusted_ca_enabled is defined and trusted_ca_enabled|bool %}
         - name: trusted-ca
           configMap:
             name: trusted-ca


### PR DESCRIPTION
Fixes for #201, it needs RBAC access to proxies, also ensure trusted_ca_enabled is defined when templating.