### PR TITLE
Bug 2044226: Add PVC role to controller service account

### DIFF
--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -398,6 +398,7 @@ spec:
           - namespaces
           - events
           - configmaps
+          - persistentvolumeclaims
           verbs:
           - get
           - list


### PR DESCRIPTION
The controller needs to be able to retrieve PVCs directly in 2.3.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2044226