### PR TITLE
Bump minKubeVersion requirement for v2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Forklift release | OpenShift Virtualization release | OpenShift release
 v2.0.0 | v4.7+ | ```v4.7+```
 v2.1.0 | v4.8+ | ```v4.8+```
 v2.2.0 | v4.9+ | ```v4.9+```
+v2.3.0 | v4.10+ | ```v4.10+```
 
 **Note:** Please keep in mind Forklift Operator will not deploy in unsupported configurations.
 

--- a/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/konveyor-forklift-operator.v99.0.0.clusterserviceversion.yaml
@@ -215,6 +215,8 @@ spec:
 
     Konveyor Forklift 2.2 is supported in OpenShift 4.9
 
+    Konveyor Forklift 2.3 is supported in OpenShift 4.10
+
     ### Documentation
     Documentation can be found on our [website](https://forklift-docs.konveyor.io).
 
@@ -509,7 +511,7 @@ spec:
   - name: Konveyor Forklift Operator
     url: https://github.com/konveyor/forklift-operator
   version: 99.0.0
-  minKubeVersion: 1.22.0
+  minKubeVersion: 1.23.0
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:


### PR DESCRIPTION
Require OCP v4.10 in preparation for v2.3.0