### PR TITLE
Bug 1994179: Use label instead of annotation for ca-trust cm

### DIFF
--- a/roles/forkliftcontroller/templates/configmap-trusted-ca.yml.j2
+++ b/roles/forkliftcontroller/templates/configmap-trusted-ca.yml.j2
@@ -6,5 +6,4 @@ metadata:
   namespace: {{ app_namespace }}
   labels:
     app: {{ app_name }}
-  annotations:
-    config.openshift.io/inject-trusted-cabundle: 'true'
+    config.openshift.io/inject-trusted-cabundle: "true"


### PR DESCRIPTION
A label should be used instead of annotations for the trusted-ca configmap , otherwise it does not get processed.