### PR TITLE
Remove targets from ansible linter workflows

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -21,8 +21,5 @@ jobs:
       - name: Ansible Lint
         uses: ansible/ansible-lint-action@master
         with:
-          targets: |
-            ./roles/forkliftcontroller/**/*.yml
-            ./roles/forkliftcontroller/**/*.yaml
           override-deps: |
             ansible-lint==5.3.2


### PR DESCRIPTION
These are causing CI jobs to fail