### PR TITLE
Refresh ansible-operator-sdk to v1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.8.0
+FROM quay.io/operator-framework/ansible-operator:v1.21
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \


### PR DESCRIPTION
- Refresh to bring in latest changes and address current CVEs
- Tested on OCP v4.10