### PR TITLE
fix syntax error in must-gather-api deployment

### DIFF
--- a/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-must-gather-api.yml.j2
@@ -51,7 +51,7 @@ spec:
 {% else %}
             - name: PORT
               value: "8080"
-            - API_TLS_ENABLED
+            - name: API_TLS_ENABLED
               value: "false"
 {% endif %}
             - name: DB_PATH


### PR DESCRIPTION
when must_gather_api_tls_enabled is false
