### PR TITLE
k8s.md: improve instructions for minikube

### DIFF
--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -5,6 +5,18 @@
 - **Kubernetes cluster or Minikube v1.17+**
 - **Operator Lifecycle Manager (OLM)**
 
+Additionally you need to configure Kubernetes API acces control. On minikube you can use ABAC authorization allowing unauthenticated access to API by creating a policy file
+
+```
+$ echo '{"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"group": "system:unauthenticated", "namespace": "*", "resource": "*", "apiGroup": "*", "nonResourcePath": "*"}}' > ~/.minikube/files/etc/ca-certificates/abac.json
+```
+
+and enabling ABAC authorization by initializing minikube with
+
+`$ minikube start --extra-config=apiserver.authorization-mode=Node,RBAC,ABAC --extra-config=apiserver.authorization-policy-file=/etc/ca-certificates/abac.json`
+
+and setting _feature_auth_required_ to false in _ForkliftController_ CR
+
 ### Installing OLM support
 
 We strongly suggest OLM support for Forklift deployments, in some production kubernetes clusters OLM might already be present, if not, see the following examples in how to add OLM support to minikube or standard kubernetes clusters below:


### PR DESCRIPTION
minikube by default doesn't use any authentication. Unauthenticated
API access needs to be enabled in minikube so that forklift-ui proxy
can access cluster-api
