### PR TITLE
add API_HOST to inventory container

### DIFF
--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -117,6 +117,8 @@ spec:
               fieldPath: metadata.namespace
         - name: ROLE
           value: inventory
+        - name: API_HOST
+          value: {{ inventory_service_name }}.{{ app_namespace }}.svc.cluster.local
         - name: KUBEVIRT_CLIENT_GO_SCHEME_REGISTRATION_VERSION
           value: "v1"
         - name: AUTH_REQUIRED


### PR DESCRIPTION
inventory talks to itself via the inventory Service, but when the API_HOST variable is not defined it binds to localhost only and is not reachable using the cluster IP that the service resolves to