### PR TITLE
Add PersistentVolumes RBAC

### DIFF
--- a/bundle/manifests/forklift-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/forklift-operator.clusterserviceversion.yaml
@@ -448,6 +448,7 @@ spec:
           - namespaces
           - events
           - configmaps
+          - persistentvolumes
           - persistentvolumeclaims
           verbs:
           - get


### PR DESCRIPTION
This patch will allow the controller to create PVs on the cluster.
It is a requirement for adding the LUN migration support.