### PR TITLE
Add admission webhook and configuration for it

### DIFF
--- a/bundle/manifests/forklift-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/forklift-operator.clusterserviceversion.yaml
@@ -432,6 +432,18 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
       - serviceAccountName: forklift-controller
         rules:
         - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,4 +54,16 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 #+kubebuilder:scaffold:rules

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -69,6 +69,7 @@ spec:
   validation_tls_enabled: false
   must_gather_api_tls_enabled: false
   ui_tls_enabled: false
+  admission_webhook: false
 EOF
 ```
 
@@ -88,5 +89,6 @@ spec:
   validation_tls_enabled: false
   must_gather_api_tls_enabled: false
   ui_tls_enabled: false
+  admission_webhook: false
 EOF
 ```

--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -95,3 +95,6 @@ must_gather_api_state: absent
 
 must_gather_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_IMAGE') or lookup( 'env', 'RELATED_IMAGE_MUST_GATHER') }}"
 virt_v2v_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VIRT_V2V') }}"
+
+admission_webhook_service_name: "{{ app_name }}-admission-webhook"
+admission_webhook_tls_secret_name: "{{ admission_webhook_service_name }}-serving-cert"

--- a/roles/forkliftcontroller/defaults/main.yml
+++ b/roles/forkliftcontroller/defaults/main.yml
@@ -96,5 +96,7 @@ must_gather_api_state: absent
 must_gather_image_fqin: "{{ lookup( 'env', 'MUST_GATHER_IMAGE') or lookup( 'env', 'RELATED_IMAGE_MUST_GATHER') }}"
 virt_v2v_image_fqin: "{{ lookup( 'env', 'VIRT_V2V_IMAGE') or lookup( 'env', 'RELATED_IMAGE_VIRT_V2V') }}"
 
+admission_webhook: true
 admission_webhook_service_name: "{{ app_name }}-admission-webhook"
 admission_webhook_tls_secret_name: "{{ admission_webhook_service_name }}-serving-cert"
+admission_webhook_port: 8444

--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -62,15 +62,18 @@
       state: present
       definition: "{{ lookup('template', 'service-inventory.yml.j2') }}"
 
-  - name: "Setup the admission webhook service"
-    k8s:
-      state: present
-      definition: "{{ lookup('template', 'service-admission-webhook.yml.j2') }}"
+  - name: "Setup admission webhook"
+    when: admission_webhook|bool
+    block:
+      - name: "Setup the admission webhook service"
+        k8s:
+          state: present
+          definition: "{{ lookup('template', 'service-admission-webhook.yml.j2') }}"
 
-  - name: "Setup the admission webhook"
-    k8s:
-      state: present
-      definition: "{{ lookup('template', 'admission-webhook-secrets.yml.j2') }}"
+      - name: "Setup the admission webhook for providers' secrets"
+        k8s:
+          state: present
+          definition: "{{ lookup('template', 'admission-webhook-providers-secrets.yml.j2') }}"
 
   - name: "Setup controller deployment"
     k8s:

--- a/roles/forkliftcontroller/tasks/main.yml
+++ b/roles/forkliftcontroller/tasks/main.yml
@@ -62,6 +62,16 @@
       state: present
       definition: "{{ lookup('template', 'service-inventory.yml.j2') }}"
 
+  - name: "Setup the admission webhook service"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'service-admission-webhook.yml.j2') }}"
+
+  - name: "Setup the admission webhook"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'admission-webhook-secrets.yml.j2') }}"
+
   - name: "Setup controller deployment"
     k8s:
       state : present

--- a/roles/forkliftcontroller/templates/admission-webhook-providers-secrets.yml.j2
+++ b/roles/forkliftcontroller/templates/admission-webhook-providers-secrets.yml.j2
@@ -10,22 +10,30 @@ metadata:
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
-- name: validator.forklift.konveyor
+- name: validator.forklift.konveyor.io
   objectSelector:
     matchLabels:
       createdForResourceType: providers
   rules:
-  - apiGroups:   [""]
-    apiVersions: ["v1beta1","v1"]
-    operations:  ["CREATE", "UPDATE"]
-    resources:   ["secrets"]
-    scope:       "Namespaced"
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1beta1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+    scope: Namespaced
   clientConfig:
     service:
       namespace: {{ app_namespace }}
       name: {{ admission_webhook_service_name }}
       path: /webhooks/provider
-      port: 8444
-  admissionReviewVersions: ["v1beta1","v1"]
+      port: {{ admission_webhook_port }}
+  admissionReviewVersions:
+  - v1beta1
+  - v1
   sideEffects: None
   timeoutSeconds: 20

--- a/roles/forkliftcontroller/templates/admission-webhook-secrets.yml.j2
+++ b/roles/forkliftcontroller/templates/admission-webhook-secrets.yml.j2
@@ -1,0 +1,31 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ admission_webhook_service_name }}
+  namespace: {{ app_namespace }}
+  labels:
+    app: {{ app_name }}
+    service: {{ admission_webhook_service_name }}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+webhooks:
+- name: validator.forklift.konveyor
+  objectSelector:
+    matchLabels:
+      createdForResourceType: providers
+  rules:
+  - apiGroups:   [""]
+    apiVersions: ["v1beta1","v1"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["secrets"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      namespace: {{ app_namespace }}
+      name: {{ admission_webhook_service_name }}
+      path: /webhooks/provider
+      port: 8444
+  admissionReviewVersions: ["v1beta1","v1"]
+  sideEffects: None
+  timeoutSeconds: 20

--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -43,7 +43,7 @@ spec:
         - name: VIRT_V2V_IMAGE
           value: {{ virt_v2v_image_fqin }}
         - name: ADMISSION_WEBHOOK_ENABLED
-          value: "true"
+          value: "{{ admission_webhook }}"
 {% if inventory_tls_enabled|bool %}
         - name: API_PORT
           value: "8443"
@@ -109,8 +109,10 @@ spec:
           readOnly: true
         - mountPath: {{ profiler_volume_path }}
           name: profiler
+{% if admission_webhook|bool %}
         - mountPath: /var/run/secrets/{{ admission_webhook_tls_secret_name }}
           name: {{ admission_webhook_tls_secret_name }}
+{% endif %}
       - name: inventory
         command:
         - /usr/local/bin/manager
@@ -208,10 +210,12 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-secret
+{% if admission_webhook|bool %}
       - name: {{ admission_webhook_tls_secret_name }}
         secret:
           defaultMode: 420
           secretName: {{ admission_webhook_tls_secret_name }}
+{% endif %}
 {% if inventory_tls_enabled|bool %}
       - name: {{ inventory_tls_secret_name }}
         secret:

--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -42,6 +42,8 @@ spec:
           value: "v1"
         - name: VIRT_V2V_IMAGE
           value: {{ virt_v2v_image_fqin }}
+        - name: ADMISSION_WEBHOOK_ENABLED
+          value: "true"
 {% if inventory_tls_enabled|bool %}
         - name: API_PORT
           value: "8443"

--- a/roles/forkliftcontroller/templates/deployment-controller.yml.j2
+++ b/roles/forkliftcontroller/templates/deployment-controller.yml.j2
@@ -107,6 +107,8 @@ spec:
           readOnly: true
         - mountPath: {{ profiler_volume_path }}
           name: profiler
+        - mountPath: /var/run/secrets/{{ admission_webhook_tls_secret_name }}
+          name: {{ admission_webhook_tls_secret_name }}
       - name: inventory
         command:
         - /usr/local/bin/manager
@@ -196,7 +198,7 @@ spec:
           name: profiler
 {% if inventory_tls_enabled|bool %}
         - mountPath: /var/run/secrets/{{ inventory_tls_secret_name }}
-          name: {{ inventory_service_name }}-serving-cert
+          name: {{ inventory_tls_secret_name }}
 {% endif %}
       terminationGracePeriodSeconds: 10
       volumes:
@@ -204,6 +206,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-secret
+      - name: {{ admission_webhook_tls_secret_name }}
+        secret:
+          defaultMode: 420
+          secretName: {{ admission_webhook_tls_secret_name }}
 {% if inventory_tls_enabled|bool %}
       - name: {{ inventory_tls_secret_name }}
         secret:

--- a/roles/forkliftcontroller/templates/service-admission-webhook.yml.j2
+++ b/roles/forkliftcontroller/templates/service-admission-webhook.yml.j2
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ admission_webhook_tls_secret_name }}
+  labels:
+    app: {{ app_name }}
+    service: {{ admission_webhook_service_name }}
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: {{ admission_webhook_service_name }}
+  namespace: {{ app_namespace }}
+spec:
+  ports:
+  - name: api-http
+    port: 8444
+    targetPort: 8444
+    protocol: TCP
+  selector:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"


### PR DESCRIPTION
The admission webhook is watching secrets with specific labels
"createdForResourceType=providers" to be created or updated.
Once the secret is created/updated the webhook triggers a call for the controller
with a said secret in the request. Inside the controller, we start the
validation and connection test.
Related to:
- https://github.com/konveyor/forklift-controller/pull/460
- https://github.com/konveyor/forklift-ui/pull/982